### PR TITLE
Filtering out repeated keys for physical down press on MS-Windows.

### DIFF
--- a/Source/windowManagers/Win32Window.cpp
+++ b/Source/windowManagers/Win32Window.cpp
@@ -414,10 +414,14 @@ static LRESULT CALLBACK WindowProcedure(HWND hwnd, UINT message, WPARAM wParam, 
 		{
 			char character = wParam; // System specific key-code
 			dsr::DsrKey dsrKey = getDsrKey(wParam); // Portable key-code
+			bool previouslyPressed = lParam & (1 << 30);
 			if (message == WM_KEYDOWN) {
-				// Physical key down
-				parent->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyDown, character, dsrKey));
-				// First press typing
+				// If not repeated
+				if (!previouslyPressed) {
+					// Physical key down
+					parent->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyDown, character, dsrKey));
+				}
+				// Press typing with repeat
 				parent->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyType, character, dsrKey));
 			} else { // message == WM_KEYUP
 				// Physical key up


### PR DESCRIPTION
MS-Windows will repeat the key down event, even if the key is not pressed again, for repeated typing. Because this framework has a separate event called KeyType, repeated input can be filtered out from the true KeyDown event.