### PR TITLE
Quick bug fixes

### DIFF
--- a/Source/DFPSR/gui/InputEvent.h
+++ b/Source/DFPSR/gui/InputEvent.h
@@ -61,11 +61,11 @@ class KeyboardEvent : public InputEvent {
 public:
 	// What the user did to the key
 	KeyboardEventType keyboardEventType;
-	// Actual characters for non-latin characters
-	char character;
+	// The raw unicode value without any encoding
+	DsrChar character;
 	// Minimal set of keys for portability
 	DsrKey dsrKey;
-	KeyboardEvent(KeyboardEventType keyboardEventType, char character, DsrKey dsrKey)
+	KeyboardEvent(KeyboardEventType keyboardEventType, DsrChar character, DsrKey dsrKey)
 	 : keyboardEventType(keyboardEventType), character(character), dsrKey(dsrKey) {}
 };
 


### PR DESCRIPTION
Trying to get Unicode input, which replaces the temporary hack, but more testing is needed. ÅÄÖ characters work on Linux and Windows, which are outside of single code UTF-8 but inside of Ansi as well.

Fixed file API for Windows, which I though was tested but some file must have been forgotten when transferring files.