### PR TITLE
Added functions for creating folders and deleting things.

### DIFF
--- a/Source/DFPSR/api/fileAPI.cpp
+++ b/Source/DFPSR/api/fileAPI.cpp
@@ -658,4 +658,18 @@ bool file_removeEmptyFolder(const ReadableString& path) {
 	return result;
 }
 
+bool file_removeFile(const ReadableString& filename) {
+	bool result = false;
+	String optimizedPath = file_optimizePath(filename, LOCAL_PATH_SYNTAX);
+	Buffer buffer;
+	const NativeChar *nativePath = toNativeString(filename, buffer);
+	// Remove the empty folder.
+	#ifdef USE_MICROSOFT_WINDOWS
+		result = (DeleteFileW(nativePath) != 0);
+	#else
+		result = (unlink(nativePath) == 0);
+	#endif
+	return result;
+}
+
 }

--- a/Source/DFPSR/api/fileAPI.cpp
+++ b/Source/DFPSR/api/fileAPI.cpp
@@ -608,4 +608,19 @@ void file_getPathEntries(const ReadableString& path, std::function<void(Readable
 	}
 }
 
+bool file_createFolder(const ReadableString &path) {
+	bool result = false;
+	String optimizedPath = file_optimizePath(path, LOCAL_PATH_SYNTAX);
+	Buffer buffer;
+	const NativeChar *nativePath = toNativeString(optimizedPath, buffer);
+	#ifdef USE_MICROSOFT_WINDOWS
+		// Create folder with permissions inherited.
+		result = (CreateDirectoryW(nativePath, nullptr) != 0);
+	#else
+		// Create folder with default permissions. Read, write and search for owner and group. Read and search for others.
+		result = (mkdir(nativePath, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == 0);
+	#endif
+	return result;
+}
+
 }

--- a/Source/DFPSR/api/fileAPI.cpp
+++ b/Source/DFPSR/api/fileAPI.cpp
@@ -242,6 +242,16 @@ ReadableString file_getPathlessName(const ReadableString &path) {
 	return string_after(path, file_findLastSeparator(path));
 }
 
+bool file_hasExtension(const String& path) {
+	int64_t lastDotIndex = string_findLast(path, U'.');
+	int64_t lastSeparatorIndex = file_findLastSeparator(path);
+	if (lastDotIndex != -1 && lastSeparatorIndex < lastDotIndex) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 ReadableString file_getExtension(const String& filename) {
 	int64_t lastDotIndex = string_findLast(filename, U'.');
 	int64_t lastSeparatorIndex = file_findLastSeparator(filename);
@@ -250,6 +260,17 @@ ReadableString file_getExtension(const String& filename) {
 		return string_removeOuterWhiteSpace(string_after(filename, lastDotIndex));
 	} else {
 		return U"";
+	}
+}
+
+ReadableString file_getExtensionless(const String& filename) {
+	int64_t lastDotIndex = string_findLast(filename, U'.');
+	int64_t lastSeparatorIndex = file_findLastSeparator(filename);
+	// Only use the last dot if there is no folder separator after it.
+	if (lastDotIndex != -1 && lastSeparatorIndex < lastDotIndex) {
+		return string_removeOuterWhiteSpace(string_before(filename, lastDotIndex));
+	} else {
+		return string_removeOuterWhiteSpace(filename);
 	}
 }
 

--- a/Source/DFPSR/api/fileAPI.cpp
+++ b/Source/DFPSR/api/fileAPI.cpp
@@ -364,7 +364,7 @@ bool file_setCurrentPath(const ReadableString &path) {
 	Buffer buffer;
 	const NativeChar *nativePath = toNativeString(file_optimizePath(path, LOCAL_PATH_SYNTAX), buffer);
 	#ifdef USE_MICROSOFT_WINDOWS
-		return SetCurrentDirectoryW(nativePath);
+		return SetCurrentDirectoryW(nativePath) != 0;
 	#else
 		return chdir(nativePath) == 0;
 	#endif
@@ -640,6 +640,20 @@ bool file_createFolder(const ReadableString &path) {
 	#else
 		// Create folder with default permissions. Read, write and search for owner and group. Read and search for others.
 		result = (mkdir(nativePath, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == 0);
+	#endif
+	return result;
+}
+
+bool file_removeEmptyFolder(const ReadableString& path) {
+	bool result = false;
+	String optimizedPath = file_optimizePath(path, LOCAL_PATH_SYNTAX);
+	Buffer buffer;
+	const NativeChar *nativePath = toNativeString(optimizedPath, buffer);
+	// Remove the empty folder.
+	#ifdef USE_MICROSOFT_WINDOWS
+		result = (RemoveDirectoryW(nativePath) != 0);
+	#else
+		result = (rmdir(nativePath) == 0);
 	#endif
 	return result;
 }

--- a/Source/DFPSR/api/fileAPI.h
+++ b/Source/DFPSR/api/fileAPI.h
@@ -24,9 +24,6 @@
 /*
 TODO:
 * Test that overwriting a large file with a smaller file does not leave anything from the overwritten file on any system.
-* bool file_createFolder(const ReadableString& path);
-	WINBASEAPI WINBOOL WINAPI CreateDirectoryW (LPCWSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes);
-	mkdir on Posix
 * bool file_remove(const ReadableString& path);
 	WINBASEAPI WINBOOL WINAPI DeleteFileW (LPCWSTR lpFileName);
 */
@@ -238,6 +235,13 @@ namespace dsr {
 	//               entryType equals file_getEntryType(entryPath).
 	// Post-condition: Returns true iff the folder could be found.
 	bool file_getFolderContent(const ReadableString& folderPath, std::function<void(const ReadableString& entryPath, const ReadableString& entryName, EntryType entryType)> action);
+
+	// Path-syntax: According to the local computer.
+	// Access permissions: Default settings according to the local operating system, either inherited from the parent folder or no specific restrictions.
+	// Pre-condition: The parent of path must already exist, because only one folder is created.
+	// Side-effects: Creates a folder at path.
+	// Post-condition: Returns true iff the operation was successful.
+	bool file_createFolder(const ReadableString &path);
 
 	// A theoretical version of file_getParentFolder for evaluation on a theoretical system without actually calling file_getCurrentPath or running on the given system.
 	// Path-syntax: Depends on pathSyntax argument.

--- a/Source/DFPSR/api/fileAPI.h
+++ b/Source/DFPSR/api/fileAPI.h
@@ -24,8 +24,8 @@
 /*
 TODO:
 * Test that overwriting a large file with a smaller file does not leave anything from the overwritten file on any system.
-* bool file_remove(const ReadableString& path);
-	WINBASEAPI WINBOOL WINAPI DeleteFileW (LPCWSTR lpFileName);
+* bool file_removeFile(const ReadableString& path);
+	bool DeleteFileW (LPCWSTR lpFileName);
 */
 
 #ifndef DFPSR_API_FILE
@@ -262,6 +262,14 @@ namespace dsr {
 	// Side-effects: Creates a folder at path.
 	// Post-condition: Returns true iff the operation was successful.
 	bool file_createFolder(const ReadableString &path);
+
+	// Path-syntax: According to the local computer.
+	// Pre-condition: The folder at path must be empty, so any recursion must be done manually.
+	//   Otherwise you might accidentally erase "C:\myFolder\importantDocuments" from giving C:\myFolder \junk instead of "C:\myFolder\junk" as command line arguments.
+	//   Better to implement your own recursive search that confirms for each file and folder that they are no longer needed, for such a dangerous operation.
+	// Side-effects: Removes the folder at path.
+	// Post-condition: Returns true iff the operation was successful.
+	bool file_removeEmptyFolder(const ReadableString& path);
 }
 
 #endif

--- a/Source/DFPSR/api/fileAPI.h
+++ b/Source/DFPSR/api/fileAPI.h
@@ -21,13 +21,6 @@
 //    3. This notice may not be removed or altered from any source
 //    distribution.
 
-/*
-TODO:
-* Test that overwriting a large file with a smaller file does not leave anything from the overwritten file on any system.
-* bool file_removeFile(const ReadableString& path);
-	bool DeleteFileW (LPCWSTR lpFileName);
-*/
-
 #ifndef DFPSR_API_FILE
 #define DFPSR_API_FILE
 
@@ -270,6 +263,12 @@ namespace dsr {
 	// Side-effects: Removes the folder at path.
 	// Post-condition: Returns true iff the operation was successful.
 	bool file_removeEmptyFolder(const ReadableString& path);
+
+	// Path-syntax: According to the local computer.
+	// Pre-condition: The file at path must exist.
+	// Side-effects: Removes the file at path. If the same file exists at multiple paths in the system, only the link to the file will be removed.
+	// Post-condition: Returns true iff the operation was successful.
+	bool file_removeFile(const ReadableString& filename);
 }
 
 #endif

--- a/Source/DFPSR/api/fileAPI.h
+++ b/Source/DFPSR/api/fileAPI.h
@@ -186,6 +186,16 @@ namespace dsr {
 	//   Use file_getEntryType instead if you want to know if it's a file or folder.
 	ReadableString file_getExtension(const String& filename);
 
+	// Path-syntax: This trivial operation should work the same independent of operating system.
+	// Post-condition: Returns filename without any extension, which is the original input if there is no extension.
+	//   Use to remove a file's type before appending a new extension.
+	ReadableString file_getExtensionless(const String& filename);
+
+	// Path-syntax: This trivial operation should work the same independent of operating system.
+	// Post-condition: Returns true iff path has an extension, even if it's just an empty dot at the end that file_getExtension would not detect.
+	//   Useful to check if you need to add an extension or if it already exists in a full filename.
+	bool file_hasExtension(const String& path);
+
 	// Quickly gets the relative parent folder by removing the last entry from the string or appending .. at the end.
 	// Path-syntax: Depends on pathSyntax argument.
 	// This pure syntax function getting the parent folder does not access the system in any way.

--- a/Source/DFPSR/api/fileAPI.h
+++ b/Source/DFPSR/api/fileAPI.h
@@ -206,10 +206,20 @@ namespace dsr {
 	// Post-condition: Returns the absolute parent to the given path, or U"?" if trying to leave the root or use a tilde home alias.
 	String file_getAbsoluteParentFolder(const ReadableString &path);
 
+	// A theoretical version of file_getAbsoluteParentFolder for evaluation on a theoretical system without actually calling file_getCurrentPath or running on the given system.
+	// Path-syntax: Depends on pathSyntax argument.
+	// Post-condition: Returns the absolute parent to the given path, or U"?" if trying to leave the root or use a tilde home alias.
+	String file_getTheoreticalAbsoluteParentFolder(const ReadableString &path, const ReadableString &currentPath, PathSyntax pathSyntax);
+
 	// Gets the canonical absolute version of the path.
 	// Path-syntax: According to the local computer.
 	// Post-condition: Returns an absolute version of the path, quickly without removing redundancy.
 	String file_getAbsolutePath(const ReadableString &path);
+
+	// A theoretical version of file_getAbsolutePath for evaluation on a theoretical system without actually calling file_getCurrentPath or running on the given system.
+	// Path-syntax: Depends on pathSyntax argument.
+	// Post-condition: Returns an absolute version of the path, quickly without removing redundancy.
+	String file_getTheoreticalAbsolutePath(const ReadableString &path, const ReadableString &currentPath, PathSyntax pathSyntax IMPLICIT_PATH_SYNTAX);
 
 	// Path-syntax: According to the local computer.
 	// Pre-condition: filename must refer to a file so that file_getEntryType(filename) == EntryType::File.
@@ -242,16 +252,6 @@ namespace dsr {
 	// Side-effects: Creates a folder at path.
 	// Post-condition: Returns true iff the operation was successful.
 	bool file_createFolder(const ReadableString &path);
-
-	// A theoretical version of file_getParentFolder for evaluation on a theoretical system without actually calling file_getCurrentPath or running on the given system.
-	// Path-syntax: Depends on pathSyntax argument.
-	// Post-condition: Returns the absolute parent to the given path, or U"?" if trying to leave the root or use a tilde home alias.
-	String file_getTheoreticalAbsoluteParentFolder(const ReadableString &path, const ReadableString &currentPath, PathSyntax pathSyntax);
-
-	// A theoretical version of for evaluation on a theoretical system without actually calling file_getCurrentPath or running on the given system.
-	// Path-syntax: Depends on pathSyntax argument.
-	// Post-condition: Returns an absolute version of the path, quickly without removing redundancy.
-	String file_getTheoreticalAbsolutePath(const ReadableString &path, const ReadableString &currentPath, PathSyntax pathSyntax IMPLICIT_PATH_SYNTAX);
 }
 
 #endif

--- a/Source/DFPSR/api/stringAPI.cpp
+++ b/Source/DFPSR/api/stringAPI.cpp
@@ -736,10 +736,12 @@ static void encodeText(const ByteWriterFunction &receiver, String content, bool 
 
 // Encoding to a buffer before saving all at once as a binary file.
 //   This tells the operating system how big the file is in advance and prevent the worst case of stalling for minutes!
-void dsr::string_save(const ReadableString& filename, const ReadableString& content, CharacterEncoding characterEncoding, LineEncoding lineEncoding) {
+bool dsr::string_save(const ReadableString& filename, const ReadableString& content, CharacterEncoding characterEncoding, LineEncoding lineEncoding) {
 	Buffer buffer = string_saveToMemory(content, characterEncoding, lineEncoding);
 	if (buffer_exists(buffer)) {
-		file_saveBuffer(filename, buffer);
+		return file_saveBuffer(filename, buffer);
+	} else {
+		return false;
 	}
 }
 

--- a/Source/DFPSR/api/stringAPI.h
+++ b/Source/DFPSR/api/stringAPI.h
@@ -288,11 +288,12 @@ String string_loadFromMemory(Buffer fileContent);
 String string_dangerous_decodeFromData(const void* data, CharacterEncoding encoding);
 
 // Side-effect: Saves content to filename using the selected character and line encodings.
+// Post-condition: Returns true on success and false on failure.
 // Do not add carriage return characters yourself into strings, for these will be added automatically in the CrLf mode.
 // The internal String type should only use UTF-32 with single line feeds for breaking lines.
 //   This makes text processing algorithms a lot cleaner when a character or line break is always one element.
 // UTF-8 with BOM is default by being both compact and capable of storing 21 bits of unicode.
-void string_save(const ReadableString& filename, const ReadableString& content,
+bool string_save(const ReadableString& filename, const ReadableString& content,
   CharacterEncoding characterEncoding = CharacterEncoding::BOM_UTF8,
   LineEncoding lineEncoding = LineEncoding::CrLf
 );

--- a/Source/test/tests/FileTest.cpp
+++ b/Source/test/tests/FileTest.cpp
@@ -57,4 +57,48 @@ START_TEST(File)
 		ASSERT_MATCH(file_getRelativeParentFolder(U"mediaFolder\\..\\myFile.txt", PathSyntax::Windows), U"");
 		ASSERT_MATCH(file_getTheoreticalAbsoluteParentFolder(U"mediaFolder\\..\\myFile.txt", U"C:\\folder\\anotherFolder", PathSyntax::Windows), U"C:\\folder\\anotherFolder");
 	}
+	{ // Path removal
+		ASSERT_MATCH(file_getPathlessName(U"C:\\..\\folder\\file.txt"), U"file.txt");
+		ASSERT_MATCH(file_getPathlessName(U"C:\\..\\folder\\"), U"");
+		ASSERT_MATCH(file_getPathlessName(U"C:\\..\\folder"), U"folder");
+		ASSERT_MATCH(file_getPathlessName(U"C:\\..\\"), U"");
+		ASSERT_MATCH(file_getPathlessName(U"C:\\.."), U"..");
+		ASSERT_MATCH(file_getPathlessName(U"C:\\"), U"");
+		ASSERT_MATCH(file_getPathlessName(U"C:"), U"C:");
+		ASSERT_MATCH(file_getPathlessName(U"/folder/file.h"), U"file.h");
+		ASSERT_MATCH(file_getPathlessName(U"/folder/"), U"");
+		ASSERT_MATCH(file_getPathlessName(U"/folder"), U"folder");
+		ASSERT_MATCH(file_getPathlessName(U"/"), U"");
+	}
+	{ // Extension removal
+		ASSERT_MATCH(file_getExtensionless(U"C:\\..\\folder\\file.txt"), U"C:\\..\\folder\\file");
+		ASSERT_MATCH(file_getExtensionless(U"C:\\folder\\file.h"), U"C:\\folder\\file");
+		ASSERT_MATCH(file_getExtensionless(U"C:\\file."), U"C:\\file");
+		ASSERT_MATCH(file_getExtensionless(U"\\file."), U"\\file");
+		ASSERT_MATCH(file_getExtensionless(U"file"), U"file");
+		ASSERT_MATCH(file_getExtensionless(U""), U"");
+		ASSERT_MATCH(file_getExtensionless(U"/folder/./file.txt"), U"/folder/./file");
+		ASSERT_MATCH(file_getExtensionless(U"/folder/file.h"), U"/folder/file");
+		ASSERT_MATCH(file_getExtensionless(U"/folder/../file.h"), U"/folder/../file");
+		ASSERT_MATCH(file_getExtensionless(U"/file."), U"/file");
+		ASSERT_MATCH(file_getExtensionless(U"file"), U"file");
+		ASSERT_MATCH(file_getExtension(U"C:\\..\\folder\\file.txt"), U"txt");
+		ASSERT_MATCH(file_getExtension(U"C:\\..\\folder\\file.foo.txt"), U"txt");
+		ASSERT_MATCH(file_getExtension(U"C:\\..\\folder\\file.foo_bar.txt"), U"txt");
+		ASSERT_MATCH(file_getExtension(U"C:\\..\\folder\\file.foo.bar_txt"), U"bar_txt");
+		ASSERT_MATCH(file_getExtension(U"C:\\folder\\file.h"), U"h");
+		ASSERT_MATCH(file_getExtension(U"C:\\file."), U"");
+		ASSERT_MATCH(file_getExtension(U"\\file."), U"");
+		ASSERT_MATCH(file_getExtension(U"file"), U"");
+		ASSERT_MATCH(file_getExtension(U""), U"");
+		ASSERT_MATCH(file_getExtension(U"/folder/./file.txt"), U"txt");
+		ASSERT_MATCH(file_getExtension(U"/folder/file.h"), U"h");
+		ASSERT_MATCH(file_getExtension(U"/folder/../file.h"), U"h");
+		ASSERT_MATCH(file_getExtension(U"/file."), U"");
+		ASSERT_MATCH(file_getExtension(U"file"), U"");
+		ASSERT_EQUAL(file_hasExtension(U"/folder/./file.txt"), true);
+		ASSERT_EQUAL(file_hasExtension(U"/../folder/file.h"), true);
+		ASSERT_EQUAL(file_hasExtension(U"/folder/file."), true); // Not a named extension, but ending with a dot is not a pure extensionless path either.
+		ASSERT_EQUAL(file_hasExtension(U"/folder/file"), false);
+	}
 END_TEST

--- a/Source/test/tests/FileTest.cpp
+++ b/Source/test/tests/FileTest.cpp
@@ -121,7 +121,9 @@ START_TEST(File)
 	{ // Nested creation and removal
 		String childPathA = file_combinePaths(U"FooBarParent", U"FooBarChildA", LOCAL_PATH_SYNTAX);
 		String childPathB = file_combinePaths(U"FooBarParent", U"FooBarChildB", LOCAL_PATH_SYNTAX);
+		String filePathC = file_combinePaths(childPathA, U"testC.txt", LOCAL_PATH_SYNTAX);
 		// Prepare by removing any old folder from aborted tests.
+		if (file_getEntryType(filePathC) == EntryType::File) file_removeFile(filePathC);
 		if (file_getEntryType(childPathA) == EntryType::Folder) file_removeEmptyFolder(childPathA);
 		if (file_getEntryType(childPathB) == EntryType::Folder) file_removeEmptyFolder(childPathB);
 		if (file_getEntryType(U"FooBarParent") == EntryType::Folder) file_removeEmptyFolder(U"FooBarParent");
@@ -131,7 +133,7 @@ START_TEST(File)
 		ASSERT_EQUAL(file_createFolder(U"FooBarParent"), true); 
 		// Check that the folder does exist.
 		ASSERT_EQUAL(file_getEntryType(U"FooBarParent"), EntryType::Folder);
-		// Create a child folder.
+		// Create child folders.
 		ASSERT_EQUAL(file_getEntryType(childPathA), EntryType::NotFound);
 		ASSERT_EQUAL(file_getEntryType(childPathB), EntryType::NotFound);
 		ASSERT_EQUAL(file_createFolder(childPathA), true);
@@ -140,6 +142,19 @@ START_TEST(File)
 		ASSERT_EQUAL(file_createFolder(childPathB), true);
 		ASSERT_EQUAL(file_getEntryType(childPathA), EntryType::Folder);
 		ASSERT_EQUAL(file_getEntryType(childPathB), EntryType::Folder);
+		// Create a file in the FooBarParent/FooBarChildA folder.
+		ASSERT_EQUAL(string_save(filePathC, U"Testing", CharacterEncoding::Raw_Latin1), true);
+		ASSERT_EQUAL(file_getEntryType(filePathC), EntryType::File);
+		ASSERT_MATCH(string_load(filePathC, false), U"Testing");
+		ASSERT_EQUAL(file_getFileSize(filePathC), 7);
+		ASSERT_EQUAL(string_save(filePathC, U"Test", CharacterEncoding::Raw_Latin1), true);
+		ASSERT_MATCH(string_load(filePathC, false), U"Test");
+		ASSERT_EQUAL(file_getFileSize(filePathC), 4);
+		ASSERT_EQUAL(file_removeEmptyFolder(childPathA), false); // Trying to remove FooBarParent/FooBarChildA now should fail.
+		// Remove the file.
+		ASSERT_EQUAL(file_removeFile(filePathC), true);
+		ASSERT_EQUAL(file_getEntryType(filePathC), EntryType::NotFound);
+		// Remove the child folders.
 		ASSERT_EQUAL(file_removeEmptyFolder(U"FooBarParent"), false); // Trying to remove the parent now should fail.
 		ASSERT_EQUAL(file_removeEmptyFolder(childPathA), true);
 		ASSERT_EQUAL(file_getEntryType(childPathA), EntryType::NotFound);
@@ -148,6 +163,7 @@ START_TEST(File)
 		ASSERT_EQUAL(file_removeEmptyFolder(childPathB), true);
 		ASSERT_EQUAL(file_getEntryType(childPathA), EntryType::NotFound);
 		ASSERT_EQUAL(file_getEntryType(childPathB), EntryType::NotFound);
+		// Remove the parent folder.
 		ASSERT_EQUAL(file_removeEmptyFolder(U"FooBarParent"), true); // Trying to remove the parent now should succeed now that it's empty.
 		ASSERT_EQUAL(file_getEntryType(U"FooBarParent"), EntryType::NotFound); // Now the parent folder should no longer exist.
 	}

--- a/Source/tools/builder/generator.cpp
+++ b/Source/tools/builder/generator.cpp
@@ -70,9 +70,8 @@ void resolveDependencies(ProjectContext &context) {
 }
 
 static String findSourceFile(const ReadableString& headerPath, bool acceptC, bool acceptCpp) {
-	int lastDotIndex = string_findLast(headerPath, U'.');
-	if (lastDotIndex != -1) {
-		ReadableString extensionlessPath = string_removeOuterWhiteSpace(string_before(headerPath, lastDotIndex));
+	if (file_hasExtension(headerPath)) {
+		ReadableString extensionlessPath = file_getExtensionless(headerPath);
 		String cPath = extensionlessPath + U".c";
 		String cppPath = extensionlessPath + U".cpp";
 		if (acceptC && file_getEntryType(cPath) == EntryType::File) {


### PR DESCRIPTION
file_getExtensionless makes it easy to change extensions for files, as used in the build system.
file_hasExtension can be used to check if an extension exists.
file_createFolder can create a folder within a parent folder.
file_removeEmptyFolder can safely remove one folder.
file_removeFile can safely remove one file.

Added lots of regression tests to make sure that all the common use cases are covered and error values are working as expected with normalized booleans. Normalized the result for file_setCurrentPath when deciding that the entire file API should normalize the booleans.