### PR TITLE
Launching applications from your program

### DIFF
--- a/Source/SDK/SpriteEngine/spriteAPI.cpp
+++ b/Source/SDK/SpriteEngine/spriteAPI.cpp
@@ -6,6 +6,7 @@
 #include "../../DFPSR/render/ITriangle2D.h"
 #include "../../DFPSR/base/endian.h"
 #include "../../DFPSR/math/scalar.h"
+#include "../../DFPSR/api/fileAPI.h"
 
 // Comment out a flag to disable an optimization when debugging
 #define DIRTY_RECTANGLE_OPTIMIZATION
@@ -191,9 +192,9 @@ public:
 	// folderPath should end with a path separator
 	SpriteType(const String& folderPath, const String& name) : name(name) {
 		// Load the image atlas
-		ImageRgbaU8 loadedAtlas = image_load_RgbaU8(string_combine(folderPath, name, U".png"));
+		ImageRgbaU8 loadedAtlas = image_load_RgbaU8(string_combine(file_combinePaths(folderPath, name), U".png"));
 		// Load the settings
-		const SpriteConfig configuration = SpriteConfig(string_load(string_combine(folderPath, name, U".ini")));
+		const SpriteConfig configuration = SpriteConfig(string_load(string_combine(file_combinePaths(folderPath, name), U".ini")));
 		this->minBoundMini = IVector3D(
 		  floor(configuration.minBound.x * ortho_miniUnitsPerTile),
 		  floor(configuration.minBound.y * ortho_miniUnitsPerTile),
@@ -272,8 +273,8 @@ public:
 		} else {
 			name = visibleModelName;
 		}
-		this->visibleModel = DenseModel_create(importer_loadModel(folderPath + visibleModelName, true, Transform3D()));
-		this->shadowModel = importer_loadModel(folderPath + shadowModelName, true, Transform3D());
+		this->visibleModel = DenseModel_create(importer_loadModel(file_combinePaths(folderPath, visibleModelName), true, Transform3D()));
+		this->shadowModel = importer_loadModel(file_combinePaths(folderPath, shadowModelName), true, Transform3D());
 	}
 	ModelType(const DenseModel& visibleModel, const Model& shadowModel)
 	: visibleModel(visibleModel), shadowModel(shadowModel) {}

--- a/Source/SDK/cube/Cube.DsrProj
+++ b/Source/SDK/cube/Cube.DsrProj
@@ -1,7 +1,8 @@
-﻿# No need to import DFPSR.DsrHead with stub backends when only including essential headers.
-CompilerFlag "-std=c++14"
+﻿CompilerFlag "-std=c++14"
+Graphics
+#Sound
 Crawl "main.cpp"
-ProgramPath = "application"
+Import "../../DFPSR/DFPSR.DsrHead"
 
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
@@ -11,6 +12,3 @@ StaticRuntime
 
 # Uncomment to enable debug mode, which is slower
 #Debug
-
-# Show how the build system works when finding the library's used subset
-ListDependencies

--- a/Source/SDK/cube/build_linux.sh
+++ b/Source/SDK/cube/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the build system with main.DsrProj and Linux selected as the platform.
+# Launch the build system with Cube.DsrProj and Linux selected as the platform.
 echo "Running build_linux.sh $@"
 chmod +x ../../tools/builder/buildProject.sh;
-../../tools/builder/buildProject.sh main.DsrProj Linux $@;
+../../tools/builder/buildProject.sh Cube.DsrProj Linux $@;

--- a/Source/SDK/cube/build_windows.bat
+++ b/Source/SDK/cube/build_windows.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Launch the build system with main.DsrProj and Windows selected as the platform.
+rem Launch the build system with Cube.DsrProj and Windows selected as the platform.
 
 echo "Running build_windows.bat %@%
-../../tools/builder/buildProject.bat main.DsrProj Windows %@%
+../../tools/builder/buildProject.bat Cube.DsrProj Windows %@%

--- a/Source/SDK/fileFinder/FileFinder.DsrProj
+++ b/Source/SDK/fileFinder/FileFinder.DsrProj
@@ -1,9 +1,6 @@
-﻿CompilerFlag "-std=c++14"
-Graphics
-#Sound
+﻿# No need to import DFPSR.DsrHead with stub backends when only including essential headers.
+CompilerFlag "-std=c++14"
 Crawl "main.cpp"
-Import "../../DFPSR/DFPSR.DsrHead"
-ProgramPath = "application"
 
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
@@ -13,3 +10,6 @@ StaticRuntime
 
 # Uncomment to enable debug mode, which is slower
 #Debug
+
+# Show how the build system works when finding the library's used subset
+ListDependencies

--- a/Source/SDK/fileFinder/build_linux.sh
+++ b/Source/SDK/fileFinder/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the build system with main.DsrProj and Linux selected as the platform.
+# Launch the build system with FileFinder.DsrProj and Linux selected as the platform.
 echo "Running build_linux.sh $@"
 chmod +x ../../tools/builder/buildProject.sh;
-../../tools/builder/buildProject.sh main.DsrProj Linux $@;
+../../tools/builder/buildProject.sh FileFinder.DsrProj Linux $@;

--- a/Source/SDK/fileFinder/build_windows.bat
+++ b/Source/SDK/fileFinder/build_windows.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Launch the build system with main.DsrProj and Windows selected as the platform.
+rem Launch the build system with FileFinder.DsrProj and Windows selected as the platform.
 
 echo "Running build_windows.bat %@%
-../../tools/builder/buildProject.bat main.DsrProj Windows %@%
+../../tools/builder/buildProject.bat FileFinder.DsrProj Windows %@%

--- a/Source/SDK/guiExample/GuiExample.DsrProj
+++ b/Source/SDK/guiExample/GuiExample.DsrProj
@@ -1,7 +1,8 @@
-﻿# No need to import DFPSR.DsrHead with stub backends when only including essential headers.
-CompilerFlag "-std=c++14"
+﻿CompilerFlag "-std=c++14"
+Graphics
+#Sound
 Crawl "main.cpp"
-ProgramPath = "application"
+Import "../../DFPSR/DFPSR.DsrHead"
 
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
@@ -11,6 +12,3 @@ StaticRuntime
 
 # Uncomment to enable debug mode, which is slower
 #Debug
-
-# Show how the build system works when finding the library's used subset
-ListDependencies

--- a/Source/SDK/guiExample/build_linux.sh
+++ b/Source/SDK/guiExample/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the build system with main.DsrProj and Linux selected as the platform.
+# Launch the build system with GuiExample.DsrProj and Linux selected as the platform.
 echo "Running build_linux.sh $@"
 chmod +x ../../tools/builder/buildProject.sh;
-../../tools/builder/buildProject.sh main.DsrProj Linux $@;
+../../tools/builder/buildProject.sh GuiExample.DsrProj Linux $@;

--- a/Source/SDK/guiExample/build_windows.bat
+++ b/Source/SDK/guiExample/build_windows.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Launch the build system with main.DsrProj and Windows selected as the platform.
+rem Launch the build system with GuiExample.DsrProj and Windows selected as the platform.
 
 echo "Running build_windows.bat %@%
-../../tools/builder/buildProject.bat main.DsrProj Windows %@%
+../../tools/builder/buildProject.bat GuiExample.DsrProj Windows %@%

--- a/Source/SDK/sandbox/Sandbox.DsrProj
+++ b/Source/SDK/sandbox/Sandbox.DsrProj
@@ -1,9 +1,16 @@
 ﻿CompilerFlag "-std=c++14"
 Graphics
 #Sound
+
+# An include using quotation marks will detect the header and its headers recursively.
+# For each detected header, the build system looks for an implementation file of the same name in the same folder.
+# Because sandbox.cpp and tool.cpp don't have sandbox.h/hpp or tool.h/hpp, the build system can't know that main depends on them.
 Crawl "main.cpp"
+# Then we just start a new crawl search from each of those disconnected include branches.
+Crawl "sandbox.cpp"
+Crawl "tool.cpp"
+
 Import "../../DFPSR/DFPSR.DsrHead"
-ProgramPath = "application"
 
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.

--- a/Source/SDK/sandbox/build_linux.sh
+++ b/Source/SDK/sandbox/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the build system with main.DsrProj and Linux selected as the platform.
+# Launch the build system with Sandbox.DsrProj and Linux selected as the platform.
 echo "Running build_linux.sh $@"
 chmod +x ../../tools/builder/buildProject.sh;
-../../tools/builder/buildProject.sh main.DsrProj Linux $@;
+../../tools/builder/buildProject.sh Sandbox.DsrProj Linux $@;

--- a/Source/SDK/sandbox/build_windows.bat
+++ b/Source/SDK/sandbox/build_windows.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Launch the build system with main.DsrProj and Windows selected as the platform.
+rem Launch the build system with Sandbox.DsrProj and Windows selected as the platform.
 
 echo "Running build_windows.bat %@%
-../../tools/builder/buildProject.bat main.DsrProj Windows %@%
+../../tools/builder/buildProject.bat Sandbox.DsrProj Windows %@%

--- a/Source/SDK/sandbox/sandbox.cpp
+++ b/Source/SDK/sandbox/sandbox.cpp
@@ -101,9 +101,9 @@ LATER:
 
 using namespace dsr;
 
-static const String mediaPath = string_combine(U"media", file_separator());
-static const String imagePath = string_combine(mediaPath, U"images", file_separator());
-static const String modelPath = string_combine(mediaPath, U"models", file_separator());
+static const String mediaPath = file_combinePaths(file_getApplicationFolder(), U"media");
+static const String imagePath = file_combinePaths(mediaPath, U"images");
+static const String modelPath = file_combinePaths(mediaPath, U"models");
 
 // Variables
 static bool running = true;
@@ -169,7 +169,7 @@ void loadModel(const ReadableString& name, const ReadableString& visibleName, co
 
 void sandbox_main() {
 	// Create the world
-	world = spriteWorld_create(OrthoSystem(string_load(string_combine(mediaPath, U"Ortho.ini"))), 256);
+	world = spriteWorld_create(OrthoSystem(string_load(file_combinePaths(mediaPath, U"Ortho.ini"))), 256);
 
 	// Create a window
 	String title = U"David Piuva's Software Renderer - Graphics sandbox";
@@ -177,7 +177,7 @@ void sandbox_main() {
 	//window = window_create_fullscreen(title);
 
 	// Load an interface to the window
-	window_loadInterfaceFromFile(window, mediaPath + U"interface.lof");
+	window_loadInterfaceFromFile(window, file_combinePaths(mediaPath, U"interface.lof"));
 
 	// Tell the application to terminate when the window is closed
 	window_setCloseEvent(window, []() {

--- a/Source/SDK/terrain/Terrain.DsrProj
+++ b/Source/SDK/terrain/Terrain.DsrProj
@@ -1,17 +1,8 @@
 ﻿CompilerFlag "-std=c++14"
 Graphics
 #Sound
-
-# An include using quotation marks will detect the header and its headers recursively.
-# For each detected header, the build system looks for an implementation file of the same name in the same folder.
-# Because sandbox.cpp and tool.cpp don't have sandbox.h/hpp or tool.h/hpp, the build system can't know that main depends on them.
 Crawl "main.cpp"
-# Then we just start a new crawl search from each of those disconnected include branches.
-Crawl "sandbox.cpp"
-Crawl "tool.cpp"
-
 Import "../../DFPSR/DFPSR.DsrHead"
-ProgramPath = "application"
 
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.

--- a/Source/SDK/terrain/build_linux.sh
+++ b/Source/SDK/terrain/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the build system with main.DsrProj and Linux selected as the platform.
+# Launch the build system with Terrain.DsrProj and Linux selected as the platform.
 echo "Running build_linux.sh $@"
 chmod +x ../../tools/builder/buildProject.sh;
-../../tools/builder/buildProject.sh main.DsrProj Linux $@;
+../../tools/builder/buildProject.sh Terrain.DsrProj Linux $@;

--- a/Source/SDK/terrain/build_windows.bat
+++ b/Source/SDK/terrain/build_windows.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Launch the build system with main.DsrProj and Windows selected as the platform.
+rem Launch the build system with Terrain.DsrProj and Windows selected as the platform.
 
 echo "Running build_windows.bat %@%
-../../tools/builder/buildProject.bat main.DsrProj Windows %@%
+../../tools/builder/buildProject.bat Terrain.DsrProj Windows %@%

--- a/Source/templates/basic3D/Basic3D.DsrProj
+++ b/Source/templates/basic3D/Basic3D.DsrProj
@@ -3,7 +3,6 @@ Graphics
 Sound
 Crawl "main.cpp"
 Import "../../DFPSR/DFPSR.DsrHead"
-ProgramPath = "application"
 
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.

--- a/Source/templates/basic3D/build_linux.sh
+++ b/Source/templates/basic3D/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the build system with main.DsrProj and Linux selected as the platform.
+# Launch the build system with Basic3D.DsrProj and Linux selected as the platform.
 echo "Running build_linux.sh $@"
 chmod +x ../../tools/builder/buildProject.sh;
-../../tools/builder/buildProject.sh main.DsrProj Linux $@;
+../../tools/builder/buildProject.sh Basic3D.DsrProj Linux $@;

--- a/Source/templates/basic3D/build_windows.bat
+++ b/Source/templates/basic3D/build_windows.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Launch the build system with main.DsrProj and Windows selected as the platform.
+rem Launch the build system with Basic3D.DsrProj and Windows selected as the platform.
 
 echo "Running build_windows.bat %@%
-../../tools/builder/buildProject.bat main.DsrProj Windows %@%
+../../tools/builder/buildProject.bat Basic3D.DsrProj Windows %@%

--- a/Source/templates/basicCLI/BasicCLI.DsrProj
+++ b/Source/templates/basicCLI/BasicCLI.DsrProj
@@ -1,9 +1,6 @@
-﻿CompilerFlag "-std=c++14"
-Graphics
-#Sound
+﻿# No need to import DFPSR.DsrHead with stub backends when only including essential headers.
+CompilerFlag "-std=c++14"
 Crawl "main.cpp"
-Import "../../DFPSR/DFPSR.DsrHead"
-ProgramPath = "application"
 
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
@@ -13,3 +10,6 @@ StaticRuntime
 
 # Uncomment to enable debug mode, which is slower
 #Debug
+
+# Show how the build system works when finding the library's used subset
+ListDependencies

--- a/Source/templates/basicCLI/build_linux.sh
+++ b/Source/templates/basicCLI/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the build system with main.DsrProj and Linux selected as the platform.
+# Launch the build system with BasicCLI.DsrProj and Linux selected as the platform.
 echo "Running build_linux.sh $@"
 chmod +x ../../tools/builder/buildProject.sh;
-../../tools/builder/buildProject.sh main.DsrProj Linux $@;
+../../tools/builder/buildProject.sh BasicCLI.DsrProj Linux $@;

--- a/Source/templates/basicCLI/build_windows.bat
+++ b/Source/templates/basicCLI/build_windows.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Launch the build system with main.DsrProj and Windows selected as the platform.
+rem Launch the build system with BasicCLI.DsrProj and Windows selected as the platform.
 
 echo "Running build_windows.bat %@%
-../../tools/builder/buildProject.bat main.DsrProj Windows %@%
+../../tools/builder/buildProject.bat BasicCLI.DsrProj Windows %@%

--- a/Source/templates/basicGUI/BasicGUI.DsrProj
+++ b/Source/templates/basicGUI/BasicGUI.DsrProj
@@ -3,7 +3,6 @@ Graphics
 Sound
 Crawl "main.cpp"
 Import "../../DFPSR/DFPSR.DsrHead"
-ProgramPath = "application"
 
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.

--- a/Source/templates/basicGUI/build_linux.sh
+++ b/Source/templates/basicGUI/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the build system with main.DsrProj and Linux selected as the platform.
+# Launch the build system with BasicGUI.DsrProj and Linux selected as the platform.
 echo "Running build_linux.sh $@"
 chmod +x ../../tools/builder/buildProject.sh;
-../../tools/builder/buildProject.sh main.DsrProj Linux $@;
+../../tools/builder/buildProject.sh BasicGUI.DsrProj Linux $@;

--- a/Source/templates/basicGUI/build_windows.bat
+++ b/Source/templates/basicGUI/build_windows.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Launch the build system with main.DsrProj and Windows selected as the platform.
+rem Launch the build system with BasicGUI.DsrProj and Windows selected as the platform.
 
 echo "Running build_windows.bat %@%
-../../tools/builder/buildProject.bat main.DsrProj Windows %@%
+../../tools/builder/buildProject.bat BasicGUI.DsrProj Windows %@%

--- a/Source/tools/builder/Machine.cpp
+++ b/Source/tools/builder/Machine.cpp
@@ -256,11 +256,14 @@ void buildProject(ScriptTarget &output, const ReadableString &projectFilePath, M
 	evaluateScript(output, context, settings, projectFilePath);
 	// Find out where things are located.
 	String projectPath = file_getAbsoluteParentFolder(projectFilePath);
-	// Interpret ProgramPath relative to the project path.
-	String fullProgramPath = getFlag(settings, U"ProgramPath", U"program");
+	// Get the project's name.
+	String projectName = file_getPathlessName(file_getExtensionless(projectFilePath));
+	// If no application path is given, the new executable will be named after the project and placed in the same folder.
+	String fullProgramPath = getFlag(settings, U"ProgramPath", projectName);
 	if (output.language == ScriptLanguage::Batch) {
 		string_append(fullProgramPath, U".exe");
 	}
+	// Interpret ProgramPath relative to the project path.
 	fullProgramPath = file_getTheoreticalAbsolutePath(fullProgramPath, projectPath);
 	// If the SkipIfBinaryExists flag is given, we will abort as soon as we have handled its external BuildProjects requests and confirmed that the application exists.
 	if (getFlagAsInteger(settings, U"SkipIfBinaryExists") && file_getEntryType(fullProgramPath) == EntryType::File) {

--- a/Source/tools/builder/Machine.cpp
+++ b/Source/tools/builder/Machine.cpp
@@ -218,7 +218,8 @@ void evaluateScript(ScriptTarget &output, ProjectContext &context, Machine &targ
 				// Insert character into quote.
 				string_appendChar(currentToken, c);
 			} else {
-				if (c == U'(' || c == U')' || c == U'[' || c == U']' || c == U'{' || c == U'}' || c == U'=') {
+				// TODO: Do the tokenization in the expression module to get the correct symbols.
+				if (c == U'(' || c == U')' || c == U'[' || c == U']' || c == U'{' || c == U'}' || c == U'=' || c == U'.' || c == U',' || c == U'|' || c == U'!' || c == U'&' || c == U'+' || c == U'-' || c == U'*' || c == U'/' || c == U'\\') {
 					// Atomic token of a single character
 					flushToken(currentLine, currentToken);
 					string_appendChar(currentToken, c);

--- a/Source/tools/wizard/Wizard.DsrProj
+++ b/Source/tools/wizard/Wizard.DsrProj
@@ -2,9 +2,12 @@
 # The caller should provide the operating system's name (Windows, Linux)
 Message "Starting main.DsrProj\n"
 
-# The wizard application is used to launch applications, so make sure that they are built before launching the selection menu.
-Build "../../SDK" SkipIfBinaryExists Supressed
-Build "../../templates" SkipIfBinaryExists Supressed
+# Give the Skip flag when compiling to only compile the wizard program itself.
+if !(Skip)
+	# The wizard application is used to launch applications, so make sure that they are built before launching the selection menu.
+	Build "../../SDK" SkipIfBinaryExists Supressed
+	Build "../../templates" SkipIfBinaryExists Supressed
+end if
 
 Message "Done with building the examples and continuing with building main.DsrProj\n"
 
@@ -29,9 +32,5 @@ Crawl "main.cpp"
 
 # Enable to compile a debug version
 # Debug
-
-# Extensionless path to the generated binary for this project.
-# Will automatically be named on each operating system.
-ProgramPath = "wizard"
 
 Message "Ending main.DsrProj\n"

--- a/Source/tools/wizard/build_linux.sh
+++ b/Source/tools/wizard/build_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the build system with main.DsrProj and Linux selected as the platform.
+# Launch the build system with Wizard.DsrProj and Linux selected as the platform.
 echo "Running build_linux.sh $@"
 chmod +x ../builder/buildProject.sh;
-../builder/buildProject.sh main.DsrProj Linux $@;
+../builder/buildProject.sh Wizard.DsrProj Linux $@;

--- a/Source/tools/wizard/build_windows.bat
+++ b/Source/tools/wizard/build_windows.bat
@@ -1,7 +1,7 @@
 @echo off
 
-rem Launch the build system with main.DsrProj and Windows selected as the platform.
+rem Launch the build system with Wizard.DsrProj and Windows selected as the platform.
 
 echo "Running build_windows.bat %@%
 
-../builder/buildProject.bat main.DsrProj Windows %@%
+../builder/buildProject.bat Wizard.DsrProj Windows %@%


### PR DESCRIPTION
Adding the ability to start another application using process_execute, which is currently placed in the file API, but with its own prefix in case of having to move it later. process_getStatus is used both to know if process_execute succeeded, if it is still running, and if it crashed once terminating.

Not giving a name to your project's binary will now automatically name it after the project file. This is used by the wizard application to automatically know the name of each binary in the SDK and template folders without having to evaluate the build scripts before launching their executables.