### PR TITLE
Building projects using direct calls to the compiler on Linux.

### DIFF
--- a/Source/DFPSR/api/fileAPI.cpp
+++ b/Source/DFPSR/api/fileAPI.cpp
@@ -745,10 +745,10 @@ DsrProcess process_execute(const ReadableString& programPath, List<String> argum
 	#endif
 	String flattenedArguments;
 	string_append(flattenedArguments, programPath);
-	string_appendChar(flattenedArguments, U'\0');
+	string_appendChar(flattenedArguments, separator);
 	for (int64_t a = 0; a < arguments.length(); a++) {
 		string_append(flattenedArguments, arguments[a]);
-		string_appendChar(flattenedArguments, U'\0');
+		string_appendChar(flattenedArguments, separator);
 	}
 	Buffer argBuffer;
 	const NativeChar *nativeArgs = toNativeString(flattenedArguments, argBuffer);

--- a/Source/templates/basicCLI/main.cpp
+++ b/Source/templates/basicCLI/main.cpp
@@ -7,6 +7,10 @@ using namespace dsr;
 
 DSR_MAIN_CALLER(dsrMain)
 void dsrMain(List<String> args) {
+	// Printing any input arguments after the program.
+	for (int i = 1; i < args.length(); i++) {
+		printText(U"args[", i, U"] = ", args[i], U"\n");
+	}
 	// Printing some text to the terminal.
 	printText(U"Hello world\n");
 }

--- a/Source/tools/builder/buildProject.bat
+++ b/Source/tools/builder/buildProject.bat
@@ -1,3 +1,20 @@
+
+rem Local build settings that should be configured before building for the first time.
+
+set CPP_COMPILER_FOLDER=C:\Program\CodeBlocks\MinGW\bin
+set CPP_COMPILER_PATH=%CPP_COMPILER_FOLDER%\x86_64-w64-mingw32-g++.exe
+
+rem Change the temporary folder if want generated scripts and objects to go somewhere else.
+set TEMPORARY_FOLDER=%TEMP%
+
+rem Select build method. (Not generating a script requires having the full path of the compiler.)
+rem set GENERATE_SCRIPT=Yes
+set GENERATE_SCRIPT=No
+
+
+
+
+
 @echo off
 
 rem Using buildProject.bat
@@ -14,11 +31,9 @@ set BUILDER_EXECUTABLE=%BUILDER_FOLDER%builder.exe
 echo BUILDER_EXECUTABLE = %BUILDER_EXECUTABLE%
 set DFPSR_LIBRARY=%BUILDER_FOLDER%..\..\DFPSR
 echo DFPSR_LIBRARY = %DFPSR_LIBRARY%
-set BUILDER_SOURCE=%BUILDER_FOLDER%\code\main.cpp %BUILDER_FOLDER%\code\Machine.cpp %BUILDER_FOLDER%\code\generator.cpp %BUILDER_FOLDER%\code\analyzer.cpp %BUILDER_FOLDER%\code\expression.cpp %DFPSR_LIBRARY%\collection\collections.cpp %DFPSR_LIBRARY%\api\fileAPI.cpp %DFPSR_LIBRARY%\api\bufferAPI.cpp %DFPSR_LIBRARY%\api\stringAPI.cpp %DFPSR_LIBRARY%\base\SafePointer.cpp
+set BUILDER_SOURCE=%BUILDER_FOLDER%\code\main.cpp %BUILDER_FOLDER%\code\Machine.cpp %BUILDER_FOLDER%\code\generator.cpp %BUILDER_FOLDER%\code\analyzer.cpp %BUILDER_FOLDER%\code\expression.cpp %DFPSR_LIBRARY%\collection\collections.cpp %DFPSR_LIBRARY%\api\fileAPI.cpp %DFPSR_LIBRARY%\api\bufferAPI.cpp %DFPSR_LIBRARY%\api\stringAPI.cpp %DFPSR_LIBRARY%\api\timeAPI.cpp %DFPSR_LIBRARY%\base\SafePointer.cpp
 echo BUILDER_SOURCE = %BUILDER_SOURCE%
 
-set CPP_COMPILER_FOLDER=C:\Program\CodeBlocks\MinGW\bin
-set CPP_COMPILER_PATH=%CPP_COMPILER_FOLDER%\x86_64-w64-mingw32-g++.exe
 echo Change CPP_COMPILER_FOLDER and CPP_COMPILER_PATH in %BUILDER_FOLDER%\buildProject.bat if you are not using %CPP_COMPILER_PATH% as your compiler.
 
 rem Check if the build system is compiled
@@ -38,15 +53,22 @@ if exist %BUILDER_EXECUTABLE% (
 	)
 )
 
-rem Call the build system with a filename for the output script, which is later called.
-set SCRIPT_PATH=%TEMP%\dfpsr_compile.bat
-echo Generating %SCRIPT_PATH% from %1%
-if exist %SCRIPT_PATH% (
-	del %SCRIPT_PATH%
+if !GENERATE_SCRIPT! EQU Yes (
+	rem Call the build system with a filename for the output script, which is later called.
+	set SCRIPT_PATH=%TEMPORARY_FOLDER%\dfpsr_compile.bat
+	echo Generating %SCRIPT_PATH% from %1%
+	if exist %SCRIPT_PATH% (
+		del %SCRIPT_PATH%
+	)
+	%BUILDER_EXECUTABLE% %SCRIPT_PATH% %* Compiler=%CPP_COMPILER_PATH% CompileFrom=%CPP_COMPILER_FOLDER%
+	if exist %SCRIPT_PATH% (
+		echo Running %SCRIPT_PATH%
+		%SCRIPT_PATH%
+	)
+) else (
+	rem Calling the build system with only the temporary folder will call the compiler directly from the build system.
+	rem   A simpler solution that works with just a single line, once the build system itself has been compiled.
+	%BUILDER_EXECUTABLE% %TEMPORARY_FOLDER% %* Compiler=%CPP_COMPILER_PATH% CompileFrom=%CPP_COMPILER_FOLDER%
 )
-%BUILDER_EXECUTABLE% %SCRIPT_PATH% %* Compiler=%CPP_COMPILER_PATH% CompileFrom=%CPP_COMPILER_FOLDER%
-if exist %SCRIPT_PATH% (
-	echo Running %SCRIPT_PATH%
-	%SCRIPT_PATH%
-)
+
 pause

--- a/Source/tools/builder/buildProject.bat
+++ b/Source/tools/builder/buildProject.bat
@@ -7,10 +7,6 @@ set CPP_COMPILER_PATH=%CPP_COMPILER_FOLDER%\x86_64-w64-mingw32-g++.exe
 rem Change the temporary folder if want generated scripts and objects to go somewhere else.
 set TEMPORARY_FOLDER=%TEMP%
 
-rem Select build method. (Not generating a script requires having the full path of the compiler.)
-rem set GENERATE_SCRIPT=Yes
-set GENERATE_SCRIPT=No
-
 
 
 
@@ -53,22 +49,19 @@ if exist %BUILDER_EXECUTABLE% (
 	)
 )
 
-if !GENERATE_SCRIPT! EQU Yes (
-	rem Call the build system with a filename for the output script, which is later called.
-	set SCRIPT_PATH=%TEMPORARY_FOLDER%\dfpsr_compile.bat
-	echo Generating %SCRIPT_PATH% from %1%
-	if exist %SCRIPT_PATH% (
-		del %SCRIPT_PATH%
-	)
-	%BUILDER_EXECUTABLE% %SCRIPT_PATH% %* Compiler=%CPP_COMPILER_PATH% CompileFrom=%CPP_COMPILER_FOLDER%
-	if exist %SCRIPT_PATH% (
-		echo Running %SCRIPT_PATH%
-		%SCRIPT_PATH%
-	)
-) else (
-	rem Calling the build system with only the temporary folder will call the compiler directly from the build system.
-	rem   A simpler solution that works with just a single line, once the build system itself has been compiled.
-	%BUILDER_EXECUTABLE% %TEMPORARY_FOLDER% %* Compiler=%CPP_COMPILER_PATH% CompileFrom=%CPP_COMPILER_FOLDER%
+rem Call the build system with a filename for the output script, which is later called.
+set SCRIPT_PATH=%TEMPORARY_FOLDER%\dfpsr_compile.bat
+echo Generating %SCRIPT_PATH% from %1%
+if exist %SCRIPT_PATH% (
+	del %SCRIPT_PATH%
 )
+%BUILDER_EXECUTABLE% %SCRIPT_PATH% %* Compiler=%CPP_COMPILER_PATH% CompileFrom=%CPP_COMPILER_FOLDER%
+if exist %SCRIPT_PATH% (
+	echo Running %SCRIPT_PATH%
+	%SCRIPT_PATH%
+)
+
+rem Calling the build system with only the temporary folder will call the compiler directly from the build system.
+rem %BUILDER_EXECUTABLE% %TEMPORARY_FOLDER% %* Compiler=%CPP_COMPILER_PATH% CompileFrom=%CPP_COMPILER_FOLDER%
 
 pause

--- a/Source/tools/builder/buildProject.sh
+++ b/Source/tools/builder/buildProject.sh
@@ -1,3 +1,20 @@
+
+# Local build settings that should be configured before building for the first time.
+
+CPP_COMPILER_PATH="/usr/bin/g++"
+echo "Change CPP_COMPILER_PATH in ${BUILDER_FOLDER}/buildProject.sh if you are not using ${CPP_COMPILER_PATH} as your compiler."
+
+# Change TEMPORARY_FOLDER if you don't want to recompile everything after each reboot, or your operating system has a different path to the temporary folder.
+TEMPORARY_FOLDER="/tmp"
+
+# Select build method. (Not generating a script requires having the full path of the compiler.)
+#GENERATE_SCRIPT="Yes"
+GENERATE_SCRIPT="No"
+
+
+
+
+
 # Using buildProject.sh
 #   $1 must be the *.DsrProj path, which is relative to the caller location.
 #   $2... are variable assignments sent as input to the given project file.
@@ -11,16 +28,13 @@ echo "BUILDER_FOLDER = ${BUILDER_FOLDER}"
 BUILDER_EXECUTABLE="${BUILDER_FOLDER}/builder"
 echo "BUILDER_EXECUTABLE = ${BUILDER_EXECUTABLE}"
 
-CPP_COMPILER_PATH="g++"
-echo "Change CPP_COMPILER_PATH in ${BUILDER_FOLDER}/buildProject.sh if you are not using ${CPP_COMPILER_PATH} as your compiler."
-
 # Check if the build system is compiled
 if [ -e "${BUILDER_EXECUTABLE}" ]; then
 	echo "Found the build system's binary."
 else
 	echo "Building the Builder build system for first time use."
 	LIBRARY_PATH="$(realpath ${BUILDER_FOLDER}/../../DFPSR)"
-	SOURCE_CODE="${BUILDER_FOLDER}/code/main.cpp ${BUILDER_FOLDER}/code/Machine.cpp ${BUILDER_FOLDER}/code/generator.cpp ${BUILDER_FOLDER}/code/analyzer.cpp ${BUILDER_FOLDER}/code/expression.cpp ${LIBRARY_PATH}/collection/collections.cpp ${LIBRARY_PATH}/api/fileAPI.cpp ${LIBRARY_PATH}/api/bufferAPI.cpp ${LIBRARY_PATH}/api/stringAPI.cpp ${LIBRARY_PATH}/base/SafePointer.cpp"
+	SOURCE_CODE="${BUILDER_FOLDER}/code/main.cpp ${BUILDER_FOLDER}/code/Machine.cpp ${BUILDER_FOLDER}/code/generator.cpp ${BUILDER_FOLDER}/code/analyzer.cpp ${BUILDER_FOLDER}/code/expression.cpp ${LIBRARY_PATH}/collection/collections.cpp ${LIBRARY_PATH}/api/fileAPI.cpp ${LIBRARY_PATH}/api/bufferAPI.cpp ${LIBRARY_PATH}/api/stringAPI.cpp ${LIBRARY_PATH}/api/timeAPI.cpp ${LIBRARY_PATH}/base/SafePointer.cpp"
 	"${CPP_COMPILER_PATH}" -o "${BUILDER_EXECUTABLE}" ${SOURCE_CODE} -std=c++14
 	if [ $? -eq 0 ]; then
 		echo "Completed building the Builder build system."
@@ -31,16 +45,25 @@ else
 fi
 chmod +x "${BUILDER_EXECUTABLE}"
 
-# Call the build system with a filename for the output script, which is later given execution permission and called.
-SCRIPT_PATH="/tmp/dfpsr_compile.sh"
-echo "Generating ${SCRIPT_PATH} from $1"
-if [ -e "${SCRIPT_PATH}" ]; then
-	rm "${SCRIPT_PATH}"
+if [ "$GENERATE_SCRIPT" == "Yes" ]; then
+	# Calling the build system with a script path will generate it with compiling and linking commands before executing the result.
+	#   Useful for debugging the output when something goes wrong.
+	SCRIPT_PATH="${TEMPORARY_FOLDER}/dfpsr_compile.sh"
+	echo "Generating ${SCRIPT_PATH} from $1"
+	if [ -e "${SCRIPT_PATH}" ]; then
+		rm "${SCRIPT_PATH}"
+	fi
+	"${BUILDER_EXECUTABLE}" "${SCRIPT_PATH}" "$@" "Compiler=${CPP_COMPILER_PATH}";
+	if [ -e "${SCRIPT_PATH}" ]; then
+		echo "Giving execution permission to ${SCRIPT_PATH}"
+		chmod +x "${SCRIPT_PATH}"
+		echo "Running ${SCRIPT_PATH}"
+		"${SCRIPT_PATH}"
+	fi
+else
+	# Calling the build system with only the temporary folder will call the compiler directly from the build system.
+	#   A simpler solution that works with just a single line, once the build system itself has been compiled.
+	echo "Generating objects to ${TEMPORARY_FOLDER} from $1"
+	"${BUILDER_EXECUTABLE}" "${TEMPORARY_FOLDER}" "$@" "Compiler=${CPP_COMPILER_PATH}";
 fi
-"${BUILDER_EXECUTABLE}" "${SCRIPT_PATH}" "$@" "Compiler=${CPP_COMPILER_PATH}";
-if [ -e "${SCRIPT_PATH}" ]; then
-	echo "Giving execution permission to ${SCRIPT_PATH}"
-	chmod +x "${SCRIPT_PATH}"
-	echo "Running ${SCRIPT_PATH}"
-	"${SCRIPT_PATH}"
-fi
+

--- a/Source/tools/builder/code/analyzer.cpp
+++ b/Source/tools/builder/code/analyzer.cpp
@@ -346,7 +346,7 @@ void gatherBuildInstructions(SessionContext &output, ProjectContext &context, Ma
 				uint64_t combinedChecksum = getCombinedChecksum(context, d);
 				String objectPath = file_combinePaths(output.tempPath, string_combine(U"dfpsr_", identityChecksum, U"_", combinedChecksum, U".o"));
 				sourceObjectIndices.push(output.sourceObjects.length());
-				output.sourceObjects.pushConstruct(identityChecksum, combinedChecksum, sourcePath, objectPath, generatedCompilerFlags, compilerName, compileFrom);
+				output.sourceObjects.pushConstruct(identityChecksum, combinedChecksum, sourcePath, objectPath, settings.compilerFlags, compilerName, compileFrom);
 			} else {
 				// Link to this pre-existing source file.
 				sourceObjectIndices.push(previousIndex);

--- a/Source/tools/builder/code/builderTypes.h
+++ b/Source/tools/builder/code/builderTypes.h
@@ -30,7 +30,11 @@ struct Machine {
 };
 
 enum class Extension {
-	Unknown, H, Hpp, C, Cpp
+	Unknown,
+	H,
+	Hpp,
+	C,
+	Cpp
 };
 
 enum class ScriptLanguage {
@@ -68,9 +72,10 @@ struct ProjectContext {
 struct SourceObject {
 	uint64_t identityChecksum = 0; // Identification number for the object's name.
 	uint64_t combinedChecksum = 0; // Combined content of the source file and all included headers recursively.
-	String sourcePath, objectPath, generatedCompilerFlags, compilerName, compileFrom;
-	SourceObject(uint64_t identityChecksum, uint64_t combinedChecksum, const ReadableString& sourcePath, const ReadableString& objectPath, const ReadableString& generatedCompilerFlags, const ReadableString& compilerName, const ReadableString& compileFrom)
-	: identityChecksum(identityChecksum), combinedChecksum(combinedChecksum), sourcePath(sourcePath), objectPath(objectPath), generatedCompilerFlags(generatedCompilerFlags), compilerName(compilerName), compileFrom(compileFrom) {}
+	String sourcePath, objectPath, compilerName, compileFrom;
+	List<String> compilerFlags;
+	SourceObject(uint64_t identityChecksum, uint64_t combinedChecksum, const ReadableString& sourcePath, const ReadableString& objectPath, const List<String> &compilerFlags, const ReadableString& compilerName, const ReadableString& compileFrom)
+	: identityChecksum(identityChecksum), combinedChecksum(combinedChecksum), sourcePath(sourcePath), objectPath(objectPath), compilerFlags(compilerFlags), compilerName(compilerName), compileFrom(compileFrom) {}
 };
 
 struct LinkingStep {

--- a/Source/tools/builder/code/generator.cpp
+++ b/Source/tools/builder/code/generator.cpp
@@ -1,101 +1,176 @@
 ﻿
 #include "generator.h"
+#include "../../../DFPSR/api/timeAPI.h"
 
 using namespace dsr;
 
-static ScriptLanguage identifyLanguage(const ReadableString &filename) {
-	String scriptExtension = string_upperCase(file_getExtension(filename));
-	if (string_match(scriptExtension, U"BAT")) {
-		return ScriptLanguage::Batch;
-	} else if (string_match(scriptExtension, U"SH")) {
-		return ScriptLanguage::Bash;
+// Keep track of the current path, so that it only changes when needed.
+String previousPath;
+
+template <bool GENERATE>
+static void produce_printMessage(String &generatedCode, ScriptLanguage language, const ReadableString message) {
+	if (GENERATE) {
+		if (language == ScriptLanguage::Batch) {
+			string_append(generatedCode, U"echo ", message, U"\n");
+		} else if (language == ScriptLanguage::Bash) {
+			string_append(generatedCode, U"echo ", message, U"\n");
+		}
 	} else {
-		throwError(U"Could not identify the scripting language of ", filename, U". Use *.bat or *.sh.\n");
-		return ScriptLanguage::Unknown;
+		printText(message, U"\n");
 	}
 }
 
-static void script_printMessage(String &output, ScriptLanguage language, const ReadableString message) {
-	if (language == ScriptLanguage::Batch) {
-		string_append(output, U"echo ", message, U"\n");
-	} else if (language == ScriptLanguage::Bash) {
-		string_append(output, U"echo ", message, U"\n");
-	}
-}
-
-static void setCompilationFolder(String &generatedCode, ScriptLanguage language, String &currentPath, const ReadableString &newPath) {
-	if (!string_match(currentPath, newPath)) {
-		if (string_length(currentPath) > 0) {
-			if (language == ScriptLanguage::Batch) {
-				string_append(generatedCode,  "popd\n");
-			} else if (language == ScriptLanguage::Bash) {
-				string_append(generatedCode, U")\n");
+template <bool GENERATE>
+static void produce_setCompilationFolder(String &generatedCode, ScriptLanguage language, const ReadableString &newPath) {
+	if (GENERATE) {
+		if (!string_match(previousPath, newPath)) {
+			if (string_length(previousPath) > 0) {
+				if (language == ScriptLanguage::Batch) {
+					string_append(generatedCode,  "popd\n");
+				} else if (language == ScriptLanguage::Bash) {
+					string_append(generatedCode, U")\n");
+				}
+			}
+			if (string_length(newPath) > 0) {
+				if (language == ScriptLanguage::Batch) {
+					string_append(generatedCode,  "pushd ", newPath, "\n");
+				} else if (language == ScriptLanguage::Bash) {
+					string_append(generatedCode, U"(cd ", newPath, ";\n");
+				}
 			}
 		}
+		previousPath = newPath;
+	} else {
 		if (string_length(newPath) > 0) {
-			if (language == ScriptLanguage::Batch) {
-				string_append(generatedCode,  "pushd ", newPath, "\n");
-			} else if (language == ScriptLanguage::Bash) {
-				string_append(generatedCode, U"(cd ", newPath, ";\n");
+			if (string_length(previousPath) == 0) {
+				previousPath = file_getCurrentPath();
 			}
+			file_setCurrentPath(newPath);
 		}
 	}
-	currentPath = newPath;
 }
 
-void generateCompilationScript(SessionContext &input, const ReadableString &scriptPath) {
-	printText(U"Generating build script\n");
-	String generatedCode;
-	ScriptLanguage language = identifyLanguage(scriptPath);
-	if (language == ScriptLanguage::Batch) {
-		string_append(generatedCode, U"@echo off\n\n");
-	} else if (language == ScriptLanguage::Bash) {
-		string_append(generatedCode, U"#!/bin/bash\n\n");
+template <bool GENERATE>
+static void produce_resetCompilationFolder(String &generatedCode, ScriptLanguage language) {
+	if (GENERATE) {
+		produce_setCompilationFolder<true>(generatedCode, language, U"");
+	} else {
+		if (string_length(previousPath) > 0) {
+			file_setCurrentPath(previousPath);
+		}
 	}
+}
 
-	// Keep track of the current path, so that it only changes when needed.
-	String currentPath;
+static bool waitForProcess(const DsrProcess &process) {
+	while (true) {
+		DsrProcessStatus status = process_getStatus(process);
+		if (status == DsrProcessStatus::Completed) {
+			return true;
+		} else if (status == DsrProcessStatus::Crashed) {
+			return false;
+		}
+		time_sleepSeconds(0.001);
+	}
+}
+
+template <bool GENERATE>
+static void produce_callProgram(String &generatedCode, ScriptLanguage language, const ReadableString &programPath, const List<String> &arguments) {
+	if (GENERATE) {
+		string_append(generatedCode, programPath);
+		for (int64_t a = 0; a < arguments.length(); a++) {
+			// TODO: Check if arguments contain spaces. In batch, adding quote marks might actually send the quote marks as a part of a string, which makes it complicated when default folder names on Windows contain spaces.
+			string_append(generatedCode, U" ", arguments[a]);
+		}
+		string_append(generatedCode, U"\n");
+	} else {
+		// Print each external call in the terminal, because there is no script to inspect when not generating.
+		if (arguments.length() > 0) {
+			printText(U"Calling ", programPath, U" with");
+			for (int64_t a = 0; a < arguments.length(); a++) {
+				printText(U" ", arguments[a]);
+			}
+			printText(U"\n");
+		} else {
+			printText(U"Calling ", programPath, U"\n");
+		}
+		// TODO: How can multiple calls be made to the compiler at the same time and only wait for all before linking?
+		//       Don't want to break control flow from the code generating a serial script, so maybe a waitForAll command before performing any linking.
+		//       Don't want error messages from multiple failed compilations to collide in the same terminal.
+		if (!waitForProcess(process_execute(programPath, arguments))) {
+			printText(U"Failed to execute ", programPath, U"!\n");
+			exit(0);
+		}
+	}
+}
+
+template <bool GENERATE>
+static void produce_callProgram(String &generatedCode, ScriptLanguage language, const ReadableString &programPath) {
+	produce_callProgram<GENERATE>(generatedCode, language, programPath, List<String>());
+}
+
+template <bool GENERATE>
+void produce(SessionContext &input, const ReadableString &scriptPath, ScriptLanguage language) {
+	String generatedCode;
+	if (GENERATE) {
+		printText(U"Generating build script\n");
+		if (language == ScriptLanguage::Batch) {
+			string_append(generatedCode, U"@echo off\n\n");
+		} else if (language == ScriptLanguage::Bash) {
+			string_append(generatedCode, U"#!/bin/bash\n\n");
+		}
+	}
 
 	// Generate code for compiling source code into objects.
-	printText(U"Generating code for compiling ", input.sourceObjects.length(), U" objects.\n");
+	printText(U"Compiling ", input.sourceObjects.length(), U" objects.\n");
 	for (int64_t o = 0; o < input.sourceObjects.length(); o++) {
 		SourceObject *sourceObject = &(input.sourceObjects[o]);
 		printText(U"\t* ", sourceObject->sourcePath, U"\n");
-		setCompilationFolder(generatedCode, language, currentPath, sourceObject->compileFrom);
-		if (language == ScriptLanguage::Batch) {
-			string_append(generatedCode,  U"if exist ", sourceObject->objectPath, U" (\n");
-		} else if (language == ScriptLanguage::Bash) {
-			string_append(generatedCode, U"if [ -e \"", sourceObject->objectPath, U"\" ]; then\n");
+		produce_setCompilationFolder<GENERATE>(generatedCode, language, sourceObject->compileFrom);
+		List<String> compilationArguments;
+		for (int64_t i = 0; i < sourceObject->compilerFlags.length(); i++) {
+			compilationArguments.push(sourceObject->compilerFlags[i]);
 		}
-		script_printMessage(generatedCode, language, string_combine(U"Reusing ", sourceObject->sourcePath, U" ID:", sourceObject->identityChecksum, U"."));
-		if (language == ScriptLanguage::Batch) {
-			string_append(generatedCode,  U") else (\n");
-		} else if (language == ScriptLanguage::Bash) {
-			string_append(generatedCode, U"else\n");
-		}
-		String compilerFlags = sourceObject->generatedCompilerFlags;
-		script_printMessage(generatedCode, language, string_combine(U"Compiling ", sourceObject->sourcePath, U" ID:", sourceObject->identityChecksum, U" with ", compilerFlags, U"."));
-		string_append(generatedCode, sourceObject->compilerName, compilerFlags, U" -c ", sourceObject->sourcePath, U" -o ", sourceObject->objectPath, U"\n");
-		if (language == ScriptLanguage::Batch) {
-			string_append(generatedCode,  ")\n");
-		} else if (language == ScriptLanguage::Bash) {
-			string_append(generatedCode, U"fi\n");
+		compilationArguments.push(U"-c");
+		compilationArguments.push(sourceObject->sourcePath);
+		compilationArguments.push(U"-o");
+		compilationArguments.push(sourceObject->objectPath);
+		if (GENERATE) {
+			if (language == ScriptLanguage::Batch) {
+				string_append(generatedCode,  U"if exist ", sourceObject->objectPath, U" (\n");
+			} else if (language == ScriptLanguage::Bash) {
+				string_append(generatedCode, U"if [ -e \"", sourceObject->objectPath, U"\" ]; then\n");
+			}
+			produce_printMessage<GENERATE>(generatedCode, language, string_combine(U"Reusing ", sourceObject->sourcePath, U" ID:", sourceObject->identityChecksum, U"."));
+			if (language == ScriptLanguage::Batch) {
+				string_append(generatedCode,  U") else (\n");
+			} else if (language == ScriptLanguage::Bash) {
+				string_append(generatedCode, U"else\n");
+			}
+			produce_printMessage<GENERATE>(generatedCode, language, string_combine(U"Compiling ", sourceObject->sourcePath, U" ID:", sourceObject->identityChecksum, U"."));
+			produce_callProgram<GENERATE>(generatedCode, language, sourceObject->compilerName, compilationArguments);
+			if (language == ScriptLanguage::Batch) {
+				string_append(generatedCode,  ")\n");
+			} else if (language == ScriptLanguage::Bash) {
+				string_append(generatedCode, U"fi\n");
+			}
+		} else {
+			if (file_getEntryType(sourceObject->objectPath) == EntryType::File) {
+				produce_printMessage<GENERATE>(generatedCode, language, string_combine(U"Reusing ", sourceObject->sourcePath, U" ID:", sourceObject->identityChecksum, U"."));
+			} else {
+				produce_printMessage<GENERATE>(generatedCode, language, string_combine(U"Compiling ", sourceObject->sourcePath, U" ID:", sourceObject->identityChecksum, U"."));
+				produce_callProgram<GENERATE>(generatedCode, language, sourceObject->compilerName, compilationArguments);
+			}
 		}
 	}
 
 	// Generate code for linking objects into executables.
-	printText(U"Generating code for linking ", input.linkerSteps.length(), U" executables:\n");
+	printText(U"Linking ", input.linkerSteps.length(), U" executables:\n");
 	for (int64_t l = 0; l < input.linkerSteps.length(); l++) {
 		LinkingStep *linkingStep = &(input.linkerSteps[l]);
 		String programPath = linkingStep->binaryName;
-		printText(U"\tGenerating code for linking ", programPath, U" of :\n");
-		setCompilationFolder(generatedCode, language, currentPath, linkingStep->compileFrom);
-		String linkerFlags;
-		for (int64_t lib = 0; lib < linkingStep->linkerFlags.length(); lib++) {
-			String linkerFlag = linkingStep->linkerFlags[lib];
-			string_append(linkerFlags, " ", linkerFlag);
-			printText(U"\t\t* ", linkerFlag, U" library\n");
-		}
+		printText(U"\tLinking ", programPath, U" of :\n");
+		produce_setCompilationFolder<GENERATE>(generatedCode, language, linkingStep->compileFrom);
+		List<String> linkerArguments;
 		// Generate a list of object paths from indices.
 		String allObjects;
 		for (int64_t i = 0; i < linkingStep->sourceObjectIndices.length(); i++) {
@@ -104,31 +179,50 @@ void generateCompilationScript(SessionContext &input, const ReadableString &scri
 			if (objectIndex >= 0 || objectIndex < input.sourceObjects.length()) {
 				printText(U"\t\t* ", sourceObject->sourcePath, U"\n");
 				string_append(allObjects, U" ", sourceObject->objectPath);
+				linkerArguments.push(sourceObject->objectPath);
 			} else {
 				throwError(U"Object index ", objectIndex, U" is out of bound ", 0, U"..", (input.sourceObjects.length() - 1), U"\n");
 			}
 		}
+		String linkerFlags;
+		for (int64_t l = 0; l < linkingStep->linkerFlags.length(); l++) {
+			String linkerFlag = linkingStep->linkerFlags[l];
+			string_append(linkerFlags, " ", linkerFlag);
+			linkerArguments.push(linkerFlag);
+			printText(U"\t\t* ", linkerFlag, U" library\n");
+		}
+		linkerArguments.push(U"-o");
+		linkerArguments.push(programPath);
 		// Generate the code for building.
 		if (string_length(linkerFlags) > 0) {
-			script_printMessage(generatedCode, language, string_combine(U"Linking ", programPath, U" with", linkerFlags, U"."));
+			produce_printMessage<GENERATE>(generatedCode, language, string_combine(U"Linking ", programPath, U" with", linkerFlags, U"."));
 		} else {
-			script_printMessage(generatedCode, language, string_combine(U"Linking ", programPath, U"."));
+			produce_printMessage<GENERATE>(generatedCode, language, string_combine(U"Linking ", programPath, U"."));
 		}
-		string_append(generatedCode, linkingStep->compilerName, allObjects, linkerFlags, U" -o ", programPath, U"\n");
+		produce_callProgram<GENERATE>(generatedCode, language, linkingStep->compilerName, linkerArguments);
 		if (linkingStep->executeResult) {
-			script_printMessage(generatedCode, language, string_combine(U"Starting ", programPath));
-			string_append(generatedCode, programPath, U"\n");
-			script_printMessage(generatedCode, language, U"The program terminated.");
+			produce_printMessage<GENERATE>(generatedCode, language, string_combine(U"Starting ", programPath));
+			produce_callProgram<GENERATE>(generatedCode, language, programPath, List<String>());
+			produce_printMessage<GENERATE>(generatedCode, language, U"The program terminated.");
 		}
 	}
-	setCompilationFolder(generatedCode, language, currentPath, U"");
-	script_printMessage(generatedCode, language, U"Done building.");
+	produce_resetCompilationFolder<GENERATE>(generatedCode, language);
+	produce_printMessage<GENERATE>(generatedCode, language, U"Done building.");
 
-	// Save the script.
-	printText(U"Saving script to ", scriptPath, "\n");
-	if (language == ScriptLanguage::Batch) {
-		string_save(scriptPath, generatedCode);
-	} else if (language == ScriptLanguage::Bash) {
-		string_save(scriptPath, generatedCode, CharacterEncoding::BOM_UTF8, LineEncoding::Lf);
+	if (GENERATE) {
+		printText(U"Saving script to ", scriptPath, "\n");
+		if (language == ScriptLanguage::Batch) {
+			string_save(scriptPath, generatedCode);
+		} else if (language == ScriptLanguage::Bash) {
+			string_save(scriptPath, generatedCode, CharacterEncoding::BOM_UTF8, LineEncoding::Lf);
+		}
 	}
+}
+
+void generateCompilationScript(SessionContext &input, const ReadableString &scriptPath, ScriptLanguage language) {
+	produce<true>(input, scriptPath, language);
+}
+
+void executeBuildInstructions(SessionContext &input) {
+	produce<false>(input, U"", ScriptLanguage::Unknown);
 }

--- a/Source/tools/builder/code/generator.h
+++ b/Source/tools/builder/code/generator.h
@@ -7,6 +7,10 @@
 
 using namespace dsr;
 
-void generateCompilationScript(SessionContext &output, const ReadableString &scriptPath);
+// Generating a script to execute later.
+void generateCompilationScript(SessionContext &input, const ReadableString &scriptPath, ScriptLanguage language);
+
+// Calling the compiler directly.
+void executeBuildInstructions(SessionContext &input);
 
 #endif

--- a/Source/tools/builder/code/main.cpp
+++ b/Source/tools/builder/code/main.cpp
@@ -4,10 +4,6 @@
 //   Otherwise buildProject.sh will just see that an old version exists and use it.
 
 // TODO:
-//  * Create a file with aliases, so that import can use
-//      Import <DFPSR>
-//    instead of
-//      Import "../../DFPSR/DFPSR.DsrHead"
 //  * Give a warning when the given compiler path is not actually a path to a file and script generation is disabled.
 //    Also make the compiler's path absolute from the current directory when called, or the specified folder to call from.
 //  * Run multiple instances of the compiler at the same time on different CPU cores.

--- a/Source/tools/builder/code/main.cpp
+++ b/Source/tools/builder/code/main.cpp
@@ -11,7 +11,6 @@
 //  * Give a warning when the given compiler path is not actually a path to a file and script generation is disabled.
 //    Also make the compiler's path absolute from the current directory when called, or the specified folder to call from.
 //  * Run multiple instances of the compiler at the same time on different CPU cores.
-//  * Improve entropy in checksums using a more advanced algorithm to reduce the risk of conflicts.
 //  * Implement more features for the machine, such as:
 //    * else and elseif cases.
 //    * Temporarily letting the theoretical path go into another folder within a scope, similar to if statements but only affecting the path.

--- a/Source/tools/wizard/main.cpp
+++ b/Source/tools/wizard/main.cpp
@@ -243,8 +243,17 @@ void dsrMain(List<String> args) {
 				// Could not find the application.
 				component_setProperty_string(descriptionLabel, U"Text", string_combine(U"Could not find the executable at ", projects[projectIndex].executableFilePath, U"!\n"), true);
 			} else if (process_getStatus(projects[projectIndex].programHandle) != DsrProcessStatus::Running) {
+				// Select input arguments.
+				List<String> arguments;
+				if (string_match(projects[projectIndex].title, U"BasicCLI")) {
+					// Give some random arguments to the CLI template, so that it will do something more than just printing "Hello World".
+					arguments.push(U"1");
+					arguments.push(U"TWO");
+					arguments.push(U"three");
+					arguments.push(U"Four");
+				}
 				// Launch the application.
-				projects[projectIndex].programHandle = process_execute(projects[projectIndex].executableFilePath, List<String>());
+				projects[projectIndex].programHandle = process_execute(projects[projectIndex].executableFilePath, arguments);
 				updateInterface(true);
 			}
 		}


### PR DESCRIPTION
On Linux, the default building method is now to call the compiler directly. For this mode, the compiler's path must point to the actual file, but one can probably check the default paths such as "/usr/bin" if they can be placed in an accessible location.

On Windows, calling the compiler directly was a bad idea (even though it's now possible using commented out code in buildProject.bat), because the cmd.exe shell application has a nasty habit of closing itself when something crashes. Always building through a generated script will make sure that you always have the last build commands saved next time cmd.exe closes unexpectedly.

Fixed a typo in the file API, so that one can send input arguments to applications on Windows. Not sure if paths will be long enough to require extra long strings with \\ prefixes, but it would be nice to keep it clean and simple without those hacks.

Waiting for a process is currently done using a delayed busy loop, in order to minimize exposure to platform specific behavior, but without hogging all the CPU cycles. Not the most efficient way of waiting, but delaying 1 to 10 milliseconds will still feel instant, while being able to play sounds and animations on the same thread.

There are now five ways of building projects, so that there are always a backup solution:
* Using Builder with direct compiler calls. (Preferred on Linux where you always have time to see errors)
* Using Builder with generated bat or sh file. (Preferred on MS-Windows where cmd.exe might close suddenly)
* Using the old recursive search build script on Linux. (If Builder won't work)
* Creating a CodeBlocks project. (Used for debugging when Valgrind is not enough)
* Calling the compiler directly from a hardcoded script. (Used to build Builder and the documentation generator to keep it simple)