### PR TITLE
Allowing buffers to be empty and other fixes

### DIFF
--- a/Doc/Buffers.html
+++ b/Doc/Buffers.html
@@ -26,7 +26,7 @@ A:active { color: #FFFFFF; background: #444444; }
 </P><P>
 </P><H1> Buffers</H1><P>Every file that is saved or loaded in the framework will pass through a Buffer.
 Buffers can not refer to each other in cycles and are automatically reference counted and deleted, so that you don't have to worry about memory leaks from them unless you explicitly call buffer_replaceDestructor.
-They store a fixed size allocation of 128-bit padded and aligned memory to work well with 128-bit SIMD intrinsics for realtime software rendering.
+They store a fixed size allocation of 128-bit padded and aligned memory to work well with 128-bit SIMD intrinsics.
 
 </P><P>
 </P><IMG SRC="Images/Border.png"><P>
@@ -38,10 +38,14 @@ Returning an empty buffer handle is common when something went wrong with an ope
 </P><P>
 To create a buffer that actually stores something, call buffer_create with the number of bytes to contain as the only argument.
 The memory always start initialized to zero, which prevents random bugs.
+
+</P><P>
+If you create a buffer of size zero, it will allocate the head but not the data.
+Trying to clone an empty buffer head will just return the same handle without cloning, because empty buffers are immutable.
 </P><IMG SRC="Images/Border.png"><P>
 </P><H2> Read and write data access</H2><P>
 </P><P>
-Trying to get the pointer of a non-existing Buffer will safely return a null pointer, no matter if you use buffer_getSafeData<type>(buffer, "Buffer name") or buffer_dangerous_getUnsafeData(buffer).
+Trying to get the pointer of a non-existing or zero length Buffer will safely return a null pointer, no matter if you use buffer_getSafeData<type>(buffer, "Buffer name") or buffer_dangerous_getUnsafeData(buffer).
 You access the data by getting a SafePointer, which can later be sliced into smaller parts.
 Sometimes you can't use the SafePointer because an operating system wants a regular C pointer.
 </P><IMG SRC="Images/Border.png"><P>

--- a/Doc/Generator/Input/Buffers.txt
+++ b/Doc/Generator/Input/Buffers.txt
@@ -3,7 +3,7 @@
 Title: Buffers
 Every file that is saved or loaded in the framework will pass through a Buffer.
 Buffers can not refer to each other in cycles and are automatically reference counted and deleted, so that you don't have to worry about memory leaks from them unless you explicitly call buffer_replaceDestructor.
-They store a fixed size allocation of 128-bit padded and aligned memory to work well with 128-bit SIMD intrinsics for realtime software rendering.
+They store a fixed size allocation of 128-bit padded and aligned memory to work well with 128-bit SIMD intrinsics.
 
 ---
 Title2: Construction
@@ -13,10 +13,13 @@ Returning an empty buffer handle is common when something went wrong with an ope
 
 To create a buffer that actually stores something, call buffer_create with the number of bytes to contain as the only argument.
 The memory always start initialized to zero, which prevents random bugs.
+
+If you create a buffer of size zero, it will allocate the head but not the data.
+Trying to clone an empty buffer head will just return the same handle without cloning, because empty buffers are immutable.
 ---
 Title2: Read and write data access
 
-Trying to get the pointer of a non-existing Buffer will safely return a null pointer, no matter if you use buffer_getSafeData<type>(buffer, "Buffer name") or buffer_dangerous_getUnsafeData(buffer).
+Trying to get the pointer of a non-existing or zero length Buffer will safely return a null pointer, no matter if you use buffer_getSafeData<type>(buffer, "Buffer name") or buffer_dangerous_getUnsafeData(buffer).
 You access the data by getting a SafePointer, which can later be sliced into smaller parts.
 Sometimes you can't use the SafePointer because an operating system wants a regular C pointer.
 ---

--- a/Source/DFPSR/License.txt
+++ b/Source/DFPSR/License.txt
@@ -1,7 +1,7 @@
 Main license for David Piuva's software renderer:
 	zlib open source license
 
-	Copyright (c) 2017 to 2021 David Forsgren Piuva
+	Copyright (c) 2017 to 2023 David Forsgren Piuva
 
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages

--- a/Source/DFPSR/api/bufferAPI.cpp
+++ b/Source/DFPSR/api/bufferAPI.cpp
@@ -103,13 +103,18 @@ BufferImpl::~BufferImpl() {
 
 Buffer buffer_clone(const Buffer &buffer) {
 	if (!buffer_exists(buffer)) {
+		// If the original buffer does not exist, just return another null handle.
 		return Buffer();
 	} else {
-		Buffer newBuffer = std::make_shared<BufferImpl>(buffer->size);
-		if (buffer->size > 0) {
+		if (buffer->size <= 0) {
+			// No need to clone when there is no shared data.
+			return buffer;
+		} else {
+			// Clone the data so that the allocations can be modified individually.
+			Buffer newBuffer = std::make_shared<BufferImpl>(buffer->size);
 			memcpy(newBuffer->data, buffer->data, buffer->size);
+			return newBuffer;
 		}
-		return newBuffer;
 	}
 }
 

--- a/Source/DFPSR/api/bufferAPI.cpp
+++ b/Source/DFPSR/api/bufferAPI.cpp
@@ -1,6 +1,6 @@
 ﻿// zlib open source license
 //
-// Copyright (c) 2019 to 2020 David Forsgren Piuva
+// Copyright (c) 2019 to 2023 David Forsgren Piuva
 // 
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages

--- a/Source/DFPSR/api/bufferAPI.h
+++ b/Source/DFPSR/api/bufferAPI.h
@@ -37,6 +37,8 @@
 //     buffer_getSize(Buffer()) == 0
 // * Empty head, used when loading a file worked but the file itself contained no data.
 //     Size equals zero, but stored in the head.
+//     Empty buffer heads will be reused when cloning, because they do not share any side-effects
+//       when there is no shared data allocation and replacing the destructor will be blocked.
 //     buffer_exists(buffer_create(0)) == true
 //     buffer_dangerous_getUnsafeData(buffer_create(0)) == nullptr
 //     buffer_getSize(buffer_create(0)) == 0

--- a/Source/DFPSR/api/bufferAPI.h
+++ b/Source/DFPSR/api/bufferAPI.h
@@ -1,6 +1,6 @@
 ﻿// zlib open source license
 //
-// Copyright (c) 2018 to 2020 David Forsgren Piuva
+// Copyright (c) 2018 to 2023 David Forsgren Piuva
 // 
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages

--- a/Source/DFPSR/api/imageAPI.cpp
+++ b/Source/DFPSR/api/imageAPI.cpp
@@ -85,7 +85,7 @@ static bool imageIsPadded(const ImageRgbaU8 &image) {
 }
 
 Buffer dsr::image_encode(const ImageRgbaU8 &image, ImageFileFormat format, int quality) {
-	if (buffer_exists) {
+	if (image_exists(image)) {
 		ImageRgbaU8 orderedImage;
 		if (image_getPackOrderIndex(image) != PackOrderIndex::RGBA) {
 			// Repack into RGBA.

--- a/Source/test/tests/BufferTest.cpp
+++ b/Source/test/tests/BufferTest.cpp
@@ -1,0 +1,28 @@
+﻿
+#include "../testTools.h"
+
+START_TEST(Buffer)
+	{
+		Buffer a; // Empty handle
+		Buffer b = buffer_create(0); // Empty buffer
+		Buffer c = buffer_create(7); // Buffer
+		ASSERT_EQUAL(buffer_exists(a), false);
+		ASSERT_EQUAL(buffer_exists(b), true);
+		ASSERT_EQUAL(buffer_exists(c), true);
+		ASSERT_EQUAL(buffer_getSize(a), 0);
+		ASSERT_EQUAL(buffer_getSize(b), 0);
+		ASSERT_EQUAL(buffer_getSize(c), 7);
+		ASSERT_EQUAL(buffer_getUseCount(a), 0);
+		ASSERT_EQUAL(buffer_getUseCount(b), 1);
+		ASSERT_EQUAL(buffer_getUseCount(c), 1);
+		Buffer d = buffer_clone(a);
+		Buffer e = buffer_clone(b); // Empty buffers are reused, which increases the use count.
+		Buffer f = buffer_clone(c);
+		ASSERT_EQUAL(buffer_getUseCount(a), 0);
+		ASSERT_EQUAL(buffer_getUseCount(b), 2);
+		ASSERT_EQUAL(buffer_getUseCount(c), 1);
+		ASSERT_EQUAL(buffer_getUseCount(d), 0);
+		ASSERT_EQUAL(buffer_getUseCount(e), 2);
+		ASSERT_EQUAL(buffer_getUseCount(f), 1);
+	}
+END_TEST

--- a/Source/test/tests/FlexTest.cpp
+++ b/Source/test/tests/FlexTest.cpp
@@ -8,7 +8,9 @@ START_TEST(Flex)
 	ASSERT_EQUAL(FlexValue(346, -54), FlexValue(100, -54)); // Limited to 100%
 	ASSERT_NOT_EQUAL(FlexValue(67, 34), FlexValue(57, 34));
 	ASSERT_NOT_EQUAL(FlexValue(14, 24), FlexValue(14, 84));
-	ASSERT_EQUAL(FlexValue(U"67%+34"), FlexValue(67, 34));
+	FlexValue a;
+	a.assignValue(U"67%+34", U"");
+	ASSERT_EQUAL(a, FlexValue(67, 34));
 	ASSERT_MATCH(FlexValue(67, 34).toString(), U"67%+34");
 END_TEST
 

--- a/Source/test/tests/PersistentTest.cpp
+++ b/Source/test/tests/PersistentTest.cpp
@@ -134,7 +134,7 @@ START_TEST(Persistent)
 	ASSERT_MATCH(myText, exampleOne);
 
 	// MyClass from text
-	std::shared_ptr<Persistent> myObjectCopy = createPersistentClassFromText(myText);
+	std::shared_ptr<Persistent> myObjectCopy = createPersistentClassFromText(myText, U"");
 	ASSERT_MATCH(myObjectCopy->toString(), myText);
 
 	// MySubClass to text
@@ -143,7 +143,7 @@ START_TEST(Persistent)
 	ASSERT_MATCH(MySubText, exampleTwo);
 
 	// MySubClass from text
-	std::shared_ptr<Persistent> mySubObjectCopy = createPersistentClassFromText(MySubText);
+	std::shared_ptr<Persistent> mySubObjectCopy = createPersistentClassFromText(MySubText, U"");
 	ASSERT_MATCH(mySubObjectCopy->toString(), MySubText);
 
 	// Tree structure to text
@@ -156,7 +156,7 @@ START_TEST(Persistent)
 	ASSERT_MATCH(tree.toString(), exampleThree);
 
 	// Tree structure from text
-	std::shared_ptr<Persistent> treeCopy = createPersistentClassFromText(exampleThree);
+	std::shared_ptr<Persistent> treeCopy = createPersistentClassFromText(exampleThree, U"");
 	ASSERT_MATCH(treeCopy->toString(), exampleThree);
 
 	// Persistent string lists
@@ -164,27 +164,27 @@ START_TEST(Persistent)
 	ASSERT_EQUAL(myList.value.length(), 0);
 	ASSERT_MATCH(myList.toString(), U"");
 
-	myList = PersistentStringList(U"\"\"");
+	myList = PersistentStringList(U"\"\"", U"");
 	ASSERT_EQUAL(myList.value.length(), 1);
 	ASSERT_MATCH(myList.value[0], U"");
 	ASSERT_MATCH(myList.toString(), U"\"\"");
 
-	myList = PersistentStringList(U"\"A\", \"B\"");
+	myList = PersistentStringList(U"\"A\", \"B\"", U"");
 	ASSERT_EQUAL(myList.value.length(), 2);
 	ASSERT_MATCH(myList.value[0], U"A");
 	ASSERT_MATCH(myList.value[1], U"B");
 	ASSERT_MATCH(myList.toString(), U"\"A\", \"B\"");
 
-	myList.assignValue(U"\"Only element\"");
+	myList.assignValue(U"\"Only element\"", U"");
 	ASSERT_EQUAL(myList.value.length(), 1);
 	ASSERT_MATCH(myList.value[0], U"Only element");
 	ASSERT_MATCH(myList.toString(), U"\"Only element\"");
 
-	myList = PersistentStringList(U"");
+	myList = PersistentStringList(U"", U"");
 	ASSERT_EQUAL(myList.value.length(), 0);
 	ASSERT_MATCH(myList.toString(), U"");
 
-	myList.assignValue(U"\"Zero 0\", \"One 1\", \"Two 2\", \"Three 3\"");
+	myList.assignValue(U"\"Zero 0\", \"One 1\", \"Two 2\", \"Three 3\"", U"");
 	ASSERT_EQUAL(myList.value.length(), 4);
 	ASSERT_MATCH(myList.value[0], U"Zero 0");
 	ASSERT_MATCH(myList.value[1], U"One 1");


### PR DESCRIPTION
To allow a buffer to correctly represent both memory allocations and files, empty buffers are now allowed by allocating them with size zero. If you only have applications without any exception catching, this will likely not break backwards compatibility. If you are making a library however, taking buffers as input should consider all features that the caller might use.