### PR TITLE
Minor fixes

### DIFF
--- a/Source/DFPSR/persistent/ClassFactory.h
+++ b/Source/DFPSR/persistent/ClassFactory.h
@@ -40,27 +40,27 @@ inline std::shared_ptr<Persistent> classConstructor() {
 
 // Must be used in each class inheriting from Persistent (both directly and indirectly)
 #define PERSISTENT_DECLARATION(CLASS) \
-	std::shared_ptr<StructureDefinition> getStructure() const override; \
-	decltype(&classConstructor) getConstructor() const override; \
-	explicit CLASS(const ReadableString &content, const ReadableString &fromPath);
+	std::shared_ptr<dsr::StructureDefinition> getStructure() const override; \
+	decltype(&dsr::classConstructor) getConstructor() const override; \
+	explicit CLASS(const dsr::ReadableString &content, const dsr::ReadableString &fromPath);
 
 // Must be used in the implementation of each class inheriting from Persistent
 #define PERSISTENT_DEFINITION(CLASS) \
-	std::shared_ptr<StructureDefinition> CLASS##Type; \
-	std::shared_ptr<StructureDefinition> CLASS::getStructure() const { \
+	std::shared_ptr<dsr::StructureDefinition> CLASS##Type; \
+	std::shared_ptr<dsr::StructureDefinition> CLASS::getStructure() const { \
 		if (CLASS##Type.get() == nullptr) { \
-			CLASS##Type = std::make_shared<StructureDefinition>(U ## #CLASS); \
+			CLASS##Type = std::make_shared<dsr::StructureDefinition>(U ## #CLASS); \
 			this->declareAttributes(*(CLASS##Type)); \
 		} \
 		return CLASS##Type; \
 	} \
-	CLASS::CLASS(const ReadableString &content, const ReadableString &fromPath) { \
+	CLASS::CLASS(const dsr::ReadableString &content, const dsr::ReadableString &fromPath) { \
 		this->assignValue(content, fromPath); \
 	} \
-	std::shared_ptr<Persistent> CLASS##Constructor() { \
-		return std::dynamic_pointer_cast<Persistent>(std::make_shared<CLASS>()); \
+	std::shared_ptr<dsr::Persistent> CLASS##Constructor() { \
+		return std::dynamic_pointer_cast<dsr::Persistent>(std::make_shared<CLASS>()); \
 	} \
-	decltype(&classConstructor) CLASS::getConstructor() const { \
+	decltype(&dsr::classConstructor) CLASS::getConstructor() const { \
 		return &CLASS##Constructor; \
 	}
 

--- a/Source/tools/builder/code/analyzer.cpp
+++ b/Source/tools/builder/code/analyzer.cpp
@@ -184,7 +184,7 @@ void analyzeFile(Dependency &result, ReadableString absolutePath, Extension exte
 	List<String> tokens;
 	bool continuingLine = false;
 	int64_t lineNumber = 0;
-	string_split_callback(sourceCode, U'\n', true, [&result, &parentFolder, &tokens, &continuingLine, &lineNumber](ReadableString line) {
+	string_split_callback(sourceCode, U'\n', true, [&result, &parentFolder, &tokens, &continuingLine, &absolutePath, &lineNumber](ReadableString line) {
 		lineNumber++;
 		if (line[0] == U'#' || continuingLine) {
 			tokenize(tokens, line);
@@ -198,8 +198,12 @@ void analyzeFile(Dependency &result, ReadableString absolutePath, Extension exte
 				if (string_match(tokens[1], U"include")) {
 					if (tokens[2][0] == U'\"') {
 						String relativePath = string_unmangleQuote(tokens[2]);
-						String absolutePath = file_getTheoreticalAbsolutePath(relativePath, parentFolder, LOCAL_PATH_SYNTAX);
-						result.includes.pushConstruct(absolutePath, lineNumber);
+						String absoluteHeaderPath = file_getTheoreticalAbsolutePath(relativePath, parentFolder, LOCAL_PATH_SYNTAX);
+						if (file_getEntryType(absoluteHeaderPath) != EntryType::File) {
+							throwError(U"Failed to find ", absoluteHeaderPath, U" from line ", lineNumber, U" in ", absolutePath, U"\n");
+						} else {
+							result.includes.pushConstruct(absoluteHeaderPath, lineNumber);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
* Making it easier to create own serializable types directly with the class factory, by using explicit namespaces in the macros to work from anywhere.

* Making it easier to debug building, by seeing missing includes directly in the build system.