### PR TITLE
Hiding cursor

### DIFF
--- a/Source/DFPSR/api/guiAPI.cpp
+++ b/Source/DFPSR/api/guiAPI.cpp
@@ -158,6 +158,16 @@ void dsr::window_setPixelScale(const Window& window, int scale) {
 	window->setPixelScale(scale);
 }
 
+bool dsr::window_setCursorVisibility(const Window& window, bool visible) {
+	MUST_EXIST(window, window_setCursorVisibility);
+	return window->backend->setCursorVisibility(visible);
+}
+
+bool dsr::window_getCursorVisibility(const Window& window) {
+	MUST_EXIST(window, window_getCursorVisibility);
+	return window->backend->visibleCursor;
+}
+
 void dsr::window_setFullScreen(const Window& window, bool enabled) {
 	MUST_EXIST(window, window_setFullScreen);
 	window->setFullScreen(enabled);

--- a/Source/DFPSR/api/guiAPI.h
+++ b/Source/DFPSR/api/guiAPI.h
@@ -126,6 +126,11 @@ namespace dsr {
 	//   Just like when handling a window resize, this will replace the canvas and depth buffer.
 	//     Any old handles to canvas and depth buffer will become useless, so fetch new image handles from the window to avoid black flickering.
 	void window_setPixelScale(const Window& window, int scale);
+	// Sets the cursor visibility for window, hiding if visible is false and showing if visible is true.
+	// Returns true on success and false on failure.
+	bool window_setCursorVisibility(const Window& window, bool visible);
+	// Returns true iff the cursor is allowed to be displayed over window.
+	bool window_getCursorVisibility(const Window& window);
 
 // Full screen
 	void window_setFullScreen(const Window& window, bool enabled);

--- a/Source/DFPSR/gui/BackendWindow.h
+++ b/Source/DFPSR/gui/BackendWindow.h
@@ -80,6 +80,11 @@ public:
 	virtual void resizeCanvas(int width, int height) = 0;
 	virtual String getTitle() { return this->title; }
 	virtual void setTitle(const String &newTitle) = 0;
+public:
+	// Cursor interface
+	bool visibleCursor = true; // Written to by setCursorVisibility on success.
+	virtual bool setCursorVisibility(bool visible) { return false; } // Returns true on success.
+public:
 	// Each callback declaration has a public variable and a public getter and setter
 	DECLARE_CALLBACK(closeEvent, emptyCallback);
 	DECLARE_CALLBACK(resizeEvent, sizeCallback);

--- a/Source/DFPSR/gui/DsrWindow.h
+++ b/Source/DFPSR/gui/DsrWindow.h
@@ -40,9 +40,10 @@ namespace dsr {
 void gui_initialize();
 
 class DsrWindow {
-private:
-	// Window backend
+public:
+	// Window backend, which the API is allowed to call directly to bypass DsrWindow for trivial operations.
 	std::shared_ptr<BackendWindow> backend;
+private:
 	// The root component
 	std::shared_ptr<VisualComponent> mainPanel;
 	AlignedImageF32 depthBuffer;

--- a/Source/templates/basic3D/main.cpp
+++ b/Source/templates/basic3D/main.cpp
@@ -63,7 +63,9 @@ Model createCubeModel(const FVector3D &min, const FVector3D &max) {
 DSR_MAIN_CALLER(dsrMain)
 void dsrMain(List<String> args) {
 	// Create a window
-	window = window_create(U"Basic 3D template", 1600, 900);
+	window = window_create_fullscreen(U"Basic 3D template");
+	// Hide the cursor
+	window_setCursorVisibility(window, false);
 
 	// Tell the application to terminate when the window is closed
 	window_setCloseEvent(window, []() {
@@ -77,7 +79,9 @@ void dsrMain(List<String> args) {
 			if (key >= DsrKey_1 && key <= DsrKey_9) {
 				window_setPixelScale(window, key - DsrKey_0);
 			} else if (key == DsrKey_F11) {
-				window_setFullScreen(window, !window_isFullScreen(window));
+				bool makeWindowed = window_isFullScreen(window);
+				window_setFullScreen(window, !makeWindowed);
+				window_setCursorVisibility(window, makeWindowed);
 			} else if (key == DsrKey_Escape) {
 				running = false;
 			}


### PR DESCRIPTION
Implemented window_setCursorVisibility for Windows and X11. Can be called with the window handle and false when enabling fullscreen for games that don't use the cursor.