### PR TITLE
Toolbar and Menu GUI components

### DIFF
--- a/Source/DFPSR/api/guiAPI.cpp
+++ b/Source/DFPSR/api/guiAPI.cpp
@@ -91,7 +91,6 @@ Component dsr::component_createWithInterfaceFromString(Component& parent, const 
 		throwError(U"component_createWithInterfaceFromString: The component could not be created!\n\nLayout:\n", content, "\n");
 	}
 	parent->addChildComponent(result);
-	result->applyLayout(parent->getSize());
 	return result;
 }
 

--- a/Source/DFPSR/gui/DsrWindow.cpp
+++ b/Source/DFPSR/gui/DsrWindow.cpp
@@ -89,7 +89,7 @@ DsrWindow::DsrWindow(std::shared_ptr<BackendWindow> backend)
 DsrWindow::~DsrWindow() {}
 
 void DsrWindow::applyLayout() {
-	this->mainPanel->applyLayout(IVector2D(this->getCanvasWidth(), this->getCanvasHeight()));
+	this->mainPanel->applyLayout(IRect(0, 0, this->getCanvasWidth(), this->getCanvasHeight()));
 }
 
 std::shared_ptr<VisualComponent> DsrWindow::findComponentByName(ReadableString name) const {

--- a/Source/DFPSR/gui/DsrWindow.cpp
+++ b/Source/DFPSR/gui/DsrWindow.cpp
@@ -30,6 +30,7 @@
 #include "components/TextBox.h"
 #include "components/Label.h"
 #include "components/Picture.h"
+#include "components/Toolbar.h"
 // <<<< Include new components here
 
 #include "../math/scalar.h"
@@ -49,6 +50,7 @@ void dsr::gui_initialize() {
 		REGISTER_PERSISTENT_CLASS(TextBox)
 		REGISTER_PERSISTENT_CLASS(Label)
 		REGISTER_PERSISTENT_CLASS(Picture)
+		REGISTER_PERSISTENT_CLASS(Toolbar)
 		// <<<< Register new components here
 
 		initialized = true;

--- a/Source/DFPSR/gui/DsrWindow.cpp
+++ b/Source/DFPSR/gui/DsrWindow.cpp
@@ -31,6 +31,7 @@
 #include "components/Label.h"
 #include "components/Picture.h"
 #include "components/Toolbar.h"
+#include "components/Menu.h"
 // <<<< Include new components here
 
 #include "../math/scalar.h"
@@ -51,6 +52,7 @@ void dsr::gui_initialize() {
 		REGISTER_PERSISTENT_CLASS(Label)
 		REGISTER_PERSISTENT_CLASS(Picture)
 		REGISTER_PERSISTENT_CLASS(Toolbar)
+		REGISTER_PERSISTENT_CLASS(Menu)
 		// <<<< Register new components here
 
 		initialized = true;
@@ -147,8 +149,12 @@ void DsrWindow::sendMouseEvent(const MouseEvent& event) {
 	MouseEvent scaledEvent = event / this->pixelScale;
 	// Send the global event
 	this->callback_windowMouseEvent(scaledEvent);
-	// Send to the main panel and its components
-	this->mainPanel->sendMouseEvent(scaledEvent);
+	if (this->mainPanel->getVisible() && this->mainPanel->pointIsInside(scaledEvent.position)) {
+		// In case of the root panel not covering the entire window, adjust input coordinates to the panel's local system.
+		scaledEvent.position -= this->mainPanel->location.upperLeft();
+		// Send to the main panel and its components
+		this->mainPanel->sendMouseEvent(scaledEvent);
+	}
 }
 
 void DsrWindow::sendKeyboardEvent(const KeyboardEvent& event) {

--- a/Source/DFPSR/gui/FlexRegion.cpp
+++ b/Source/DFPSR/gui/FlexRegion.cpp
@@ -59,10 +59,10 @@ String& FlexValue::toStreamIndented(String& out, const ReadableString& indentati
 
 IRect FlexRegion::getNewLocation(const IRect &givenSpace) {
 	return IRect::FromBounds(
-		this->sides[0].getValue(givenSpace.left(), givenSpace.right()),
-		this->sides[1].getValue(givenSpace.top(), givenSpace.bottom()),
-		this->sides[2].getValue(givenSpace.left(), givenSpace.right()),
-		this->sides[3].getValue(givenSpace.top(), givenSpace.bottom())
+		this->left.getValue(givenSpace.left(), givenSpace.right()),
+		this->top.getValue(givenSpace.top(), givenSpace.bottom()),
+		this->right.getValue(givenSpace.left(), givenSpace.right()),
+		this->bottom.getValue(givenSpace.top(), givenSpace.bottom())
 	);
 }
 

--- a/Source/DFPSR/gui/FlexRegion.cpp
+++ b/Source/DFPSR/gui/FlexRegion.cpp
@@ -57,12 +57,12 @@ String& FlexValue::toStreamIndented(String& out, const ReadableString& indentati
 	return out;
 }
 
-IRect FlexRegion::getNewLocation(const IVector2D &parentSize) {
+IRect FlexRegion::getNewLocation(const IRect &givenSpace) {
 	return IRect::FromBounds(
-		this->sides[0].getValue(parentSize.x),
-		this->sides[1].getValue(parentSize.y),
-		this->sides[2].getValue(parentSize.x),
-		this->sides[3].getValue(parentSize.y)
+		this->sides[0].getValue(givenSpace.left(), givenSpace.right()),
+		this->sides[1].getValue(givenSpace.top(), givenSpace.bottom()),
+		this->sides[2].getValue(givenSpace.left(), givenSpace.right()),
+		this->sides[3].getValue(givenSpace.top(), givenSpace.bottom())
 	);
 }
 

--- a/Source/DFPSR/gui/FlexRegion.h
+++ b/Source/DFPSR/gui/FlexRegion.h
@@ -46,7 +46,7 @@ public:
 public:
 	int32_t getRatio() const { return this->ratio; }
 	int32_t getOffset() const { return this->offset; }
-	int32_t getValue(int32_t parentValue) const { return (parentValue * this->ratio) / 100 + this->offset; }
+	int32_t getValue(int32_t minimum, int32_t maximum) const { return ((minimum * (100 - this->ratio)) + (maximum * this->ratio)) / 100 + this->offset; }
 };
 inline bool operator==(const FlexValue &left, const FlexValue &right) {
 	return left.getRatio() == right.getRatio() && left.getOffset() == right.getOffset();
@@ -98,7 +98,7 @@ public:
 		this->setBottom(bottom);
 	}
 public:
-	virtual IRect getNewLocation(const IVector2D &parentSize);
+	virtual IRect getNewLocation(const IRect &givenSpace);
 };
 
 }

--- a/Source/DFPSR/gui/FlexRegion.h
+++ b/Source/DFPSR/gui/FlexRegion.h
@@ -57,38 +57,37 @@ inline bool operator!=(const FlexValue &left, const FlexValue &right) {
 
 struct FlexRegion {
 public:
-	// Indices: 0 = left, 1 = top, 2 = right, 3 = bottom
-	FlexValue sides[4];
+	FlexValue left, top, right, bottom;
 public:
-	void setLeft(const FlexValue &left) { this->sides[0] = left; }
-	void setTop(const FlexValue &top) { this->sides[1] = top; }
-	void setRight(const FlexValue &right) { this->sides[2] = right; }
-	void setBottom(const FlexValue &bottom) { this->sides[3] = bottom; }
-	void setLeft(const ReadableString &left) { this->sides[0] = FlexValue(left, U""); }
-	void setTop(const ReadableString &top) { this->sides[1] = FlexValue(top, U""); }
-	void setRight(const ReadableString &right) { this->sides[2] = FlexValue(right, U""); }
-	void setBottom(const ReadableString &bottom) { this->sides[3] = FlexValue(bottom, U""); }
+	void setLeft(const FlexValue &left) { this->left = left; }
+	void setTop(const FlexValue &top) { this->top = top; }
+	void setRight(const FlexValue &right) { this->right = right; }
+	void setBottom(const FlexValue &bottom) { this->bottom = bottom; }
+	void setLeft(const ReadableString &left) { this->left = FlexValue(left, U""); }
+	void setTop(const ReadableString &top) { this->top = FlexValue(top, U""); }
+	void setRight(const ReadableString &right) { this->right = FlexValue(right, U""); }
+	void setBottom(const ReadableString &bottom) { this->bottom = FlexValue(bottom, U""); }
 public:
 	// Full region
 	FlexRegion() {
-		this->sides[0] = FlexValue(0, 0);
-		this->sides[1] = FlexValue(0, 0);
-		this->sides[2] = FlexValue(100, 0);
-		this->sides[3] = FlexValue(100, 0);
+		this->left = FlexValue(0, 0);
+		this->top = FlexValue(0, 0);
+		this->right = FlexValue(100, 0);
+		this->bottom = FlexValue(100, 0);
 	}
 	// Upper left aligned region
 	explicit FlexRegion(const IRect &location) {
-		this->sides[0] = FlexValue(0, location.left());
-		this->sides[1] = FlexValue(0, location.top());
-		this->sides[2] = FlexValue(0, location.right());
-		this->sides[3] = FlexValue(0, location.bottom());
+		this->left = FlexValue(0, location.left());
+		this->top = FlexValue(0, location.top());
+		this->right = FlexValue(0, location.right());
+		this->bottom = FlexValue(0, location.bottom());
 	}
 	// Flexible region
 	FlexRegion(int leftRatio, int leftOffset, int topRatio, int topOffset, int rightRatio, int rightOffset, int bottomRatio, int bottomOffset) {
-		this->sides[0] = FlexValue(leftRatio, leftOffset);
-		this->sides[1] = FlexValue(topRatio, topOffset);
-		this->sides[2] = FlexValue(rightRatio, rightOffset);
-		this->sides[3] = FlexValue(bottomRatio, bottomOffset);
+		this->left = FlexValue(leftRatio, leftOffset);
+		this->top = FlexValue(topRatio, topOffset);
+		this->right = FlexValue(rightRatio, rightOffset);
+		this->bottom = FlexValue(bottomRatio, bottomOffset);
 	}
 	// Parse individual flex values from text
 	FlexRegion(const ReadableString &left, const ReadableString &top, const ReadableString &right, const ReadableString &bottom) {

--- a/Source/DFPSR/gui/InputEvent.h
+++ b/Source/DFPSR/gui/InputEvent.h
@@ -37,7 +37,7 @@ public:
 
 enum class KeyboardEventType { KeyDown, KeyUp, KeyType };
 
-// The DsrKey enumeration is convertible to integers allow certain well defined math operations
+// The DsrKey enumeration is convertible to integers and allow certain well defined math operations
 // Safe assumptions:
 //   * DsrKey_0 to DsrKey_9 are guaranteed to be in an increasing serial order (so that "key - DsrKey_0" is the key's number)
 //   * DsrKey_F1 to DsrKey_F12 are guaranteed to be in an increasing serial order (so that "key - (DsrKey_F1 - 1)" is the key's number)

--- a/Source/DFPSR/gui/VisualComponent.h
+++ b/Source/DFPSR/gui/VisualComponent.h
@@ -186,7 +186,7 @@ public:
 	//   If the parent has decorations around the child components, the region may include some padding from which the flexible regions calculate the locations from in percents.
 	//     For example: A given space from 10 to 90 pixels will have 0% at 10 and 100% at 90.
 	//   A toolbar may give non-overlapping spaces that are assigned automatically to simplify the process of maintaining the layout while adding and removing child components.
-	// TODO: How can internal changes to inner dimensions be detected by the parent to run this method again? Call the parent and tell it to update next time something needs drawing or mouse input?
+	// TODO: How can internal changes to inner dimensions be detected by the parent to run this method again?
 	virtual void applyLayout(const IRect& givenSpace);
 	// Update layout when the component moved but the parent has the same dimensions
 	void updateLayout();

--- a/Source/DFPSR/gui/VisualComponent.h
+++ b/Source/DFPSR/gui/VisualComponent.h
@@ -76,16 +76,16 @@ public:
 			return &(this->visible);
 		} else if (string_caseInsensitiveMatch(name, U"Left")) {
 			this->regionAccessed = true;
-			return &(this->region.sides[0]);
+			return &(this->region.left);
 		} else if (string_caseInsensitiveMatch(name, U"Top")) {
 			this->regionAccessed = true;
-			return &(this->region.sides[1]);
+			return &(this->region.top);
 		} else if (string_caseInsensitiveMatch(name, U"Right")) {
 			this->regionAccessed = true;
-			return &(this->region.sides[2]);
+			return &(this->region.right);
 		} else if (string_caseInsensitiveMatch(name, U"Bottom")) {
 			this->regionAccessed = true;
-			return &(this->region.sides[3]);
+			return &(this->region.bottom);
 		} else {
 			return nullptr;
 		}
@@ -205,7 +205,7 @@ public:
 	virtual bool pointIsInside(const IVector2D& pixelPosition);
 	// Get a pointer to the topmost child
 	// Invisible components are ignored by default, but includeInvisible can be enabled to change that.
-	// Returns an empty reference if the pixel position didn't hit anything inside.
+	// Returns an empty reference if the pixel position didn't hit anything in
 	// Since the root component might not be heap allocated, it cannot return itself by reference.
 	//   Use pointIsInside if your root component doesn't cover the whole window.
 	std::shared_ptr<VisualComponent> getTopChild(const IVector2D& pixelPosition, bool includeInvisible = false);

--- a/Source/DFPSR/gui/VisualTheme.cpp
+++ b/Source/DFPSR/gui/VisualTheme.cpp
@@ -217,6 +217,15 @@ UR"QUOTE(
 	[Toolbar]
 		border = 1
 		method = "HardRectangle"
+	[MenuTop]
+		border = 1
+		method = "HardRectangle"
+	[MenuSub]
+		border = 1
+		method = "HardRectangle"
+	[MenuList]
+		border = 1
+		method = "HardRectangle"
 )QUOTE";
 
 template <typename V>

--- a/Source/DFPSR/gui/VisualTheme.cpp
+++ b/Source/DFPSR/gui/VisualTheme.cpp
@@ -214,6 +214,9 @@ UR"QUOTE(
 	[Panel]
 		border = 1
 		method = "HardRectangle"
+	[Toolbar]
+		border = 1
+		method = "HardRectangle"
 )QUOTE";
 
 template <typename V>

--- a/Source/DFPSR/gui/components/Button.cpp
+++ b/Source/DFPSR/gui/components/Button.cpp
@@ -108,7 +108,7 @@ bool Button::pointIsInside(const IVector2D& pixelPosition) {
 	// Get the point relative to the component instead of its direct container
 	IVector2D localPoint = pixelPosition - this->location.upperLeft();
 	// Sample opacity at the location
-	return dsr::image_readPixel_border(this->imageUp, localPoint.x, localPoint.y).alpha > 127;
+	return image_readPixel_border(this->imageUp, localPoint.x, localPoint.y).alpha > 127;
 }
 
 void Button::changedTheme(VisualTheme newTheme) {

--- a/Source/DFPSR/gui/components/Button.cpp
+++ b/Source/DFPSR/gui/components/Button.cpp
@@ -32,6 +32,7 @@ void Button::declareAttributes(StructureDefinition &target) const {
 	VisualComponent::declareAttributes(target);
 	target.declareAttribute(U"Color");
 	target.declareAttribute(U"Text");
+	target.declareAttribute(U"Padding");
 }
 
 Persistent* Button::findAttribute(const ReadableString &name) {
@@ -42,6 +43,8 @@ Persistent* Button::findAttribute(const ReadableString &name) {
 		return &(this->foreColor);
 	} else if (string_caseInsensitiveMatch(name, U"Text")) {
 		return &(this->text);
+	} else if (string_caseInsensitiveMatch(name, U"Padding")) {
+		return &(this->padding);
 	} else {
 		return VisualComponent::findAttribute(name);
 	}
@@ -132,4 +135,10 @@ void Button::changedAttribute(const ReadableString &name) {
 	if (!string_caseInsensitiveMatch(name, U"Visible")) {
 		this->hasImages = false;
 	}
+}
+
+IVector2D Button::getDesiredDimensions() {
+	this->completeAssets();
+	int sizeAdder = this->padding.value * 2;
+	return IVector2D(font_getLineWidth(this->font, this->text.value) + sizeAdder, font_getSize(this->font) + sizeAdder);
 }

--- a/Source/DFPSR/gui/components/Button.cpp
+++ b/Source/DFPSR/gui/components/Button.cpp
@@ -30,7 +30,8 @@ PERSISTENT_DEFINITION(Button)
 
 void Button::declareAttributes(StructureDefinition &target) const {
 	VisualComponent::declareAttributes(target);
-	target.declareAttribute(U"Color");
+	target.declareAttribute(U"BackColor");
+	target.declareAttribute(U"ForeColor");
 	target.declareAttribute(U"Text");
 	target.declareAttribute(U"Padding");
 }

--- a/Source/DFPSR/gui/components/Button.h
+++ b/Source/DFPSR/gui/components/Button.h
@@ -36,6 +36,7 @@ public:
 	PersistentColor backColor;
 	PersistentColor foreColor;
 	PersistentString text;
+	PersistentInteger padding = PersistentInteger(5); // How many pixels of padding are applied on each side of the text when calculating desired dimensions for placing in toolbars.
 	void declareAttributes(StructureDefinition &target) const override;
 	Persistent* findAttribute(const ReadableString &name) override;
 private:
@@ -61,6 +62,7 @@ public:
 	void changedTheme(VisualTheme newTheme) override;
 	void changedLocation(const IRect &oldLocation, const IRect &newLocation) override;
 	void changedAttribute(const ReadableString &name) override;
+	IVector2D getDesiredDimensions() override;
 };
 
 }

--- a/Source/DFPSR/gui/components/Button.h
+++ b/Source/DFPSR/gui/components/Button.h
@@ -33,8 +33,8 @@ class Button : public VisualComponent {
 PERSISTENT_DECLARATION(Button)
 public:
 	// Attributes
-	PersistentColor backColor;
-	PersistentColor foreColor;
+	PersistentColor backColor = PersistentColor(130, 130, 130);
+	PersistentColor foreColor = PersistentColor(0, 0, 0);
 	PersistentString text;
 	PersistentInteger padding = PersistentInteger(5); // How many pixels of padding are applied on each side of the text when calculating desired dimensions for placing in toolbars.
 	void declareAttributes(StructureDefinition &target) const override;

--- a/Source/DFPSR/gui/components/Label.cpp
+++ b/Source/DFPSR/gui/components/Label.cpp
@@ -33,6 +33,7 @@ void Label::declareAttributes(StructureDefinition &target) const {
 	target.declareAttribute(U"Color");
 	target.declareAttribute(U"Opacity");
 	target.declareAttribute(U"Text");
+	target.declareAttribute(U"Padding");
 }
 
 Persistent* Label::findAttribute(const ReadableString &name) {
@@ -43,6 +44,8 @@ Persistent* Label::findAttribute(const ReadableString &name) {
 		return &(this->opacity);
 	} else if (string_caseInsensitiveMatch(name, U"Text")) {
 		return &(this->text);
+	} else if (string_caseInsensitiveMatch(name, U"Padding")) {
+		return &(this->padding);
 	} else {
 		return VisualComponent::findAttribute(name);
 	}
@@ -75,3 +78,8 @@ void Label::completeAssets() {
 	}
 }
 
+IVector2D Label::getDesiredDimensions() {
+	this->completeAssets();
+	int sizeAdder = this->padding.value * 2;
+	return IVector2D(font_getLineWidth(this->font, this->text.value) + sizeAdder, font_getSize(this->font) + sizeAdder);
+}

--- a/Source/DFPSR/gui/components/Label.h
+++ b/Source/DFPSR/gui/components/Label.h
@@ -33,7 +33,7 @@ class Label : public VisualComponent {
 PERSISTENT_DECLARATION(Label)
 public:
 	// Attributes
-	PersistentColor color;
+	PersistentColor color = PersistentColor(0, 0, 0);
 	// TODO: Why is "PersistentInteger opacity(255);" not recognizing the constructor?
 	PersistentInteger opacity = PersistentInteger(255); // 0 is fully invisible, 255 is fully opaque
 	PersistentString text;

--- a/Source/DFPSR/gui/components/Label.h
+++ b/Source/DFPSR/gui/components/Label.h
@@ -37,6 +37,7 @@ public:
 	// TODO: Why is "PersistentInteger opacity(255);" not recognizing the constructor?
 	PersistentInteger opacity = PersistentInteger(255); // 0 is fully invisible, 255 is fully opaque
 	PersistentString text;
+	PersistentInteger padding = PersistentInteger(3); // How many pixels of padding are applied on each side of the text when calculating desired dimensions for placing in toolbars.
 	// Attribute access
 	void declareAttributes(StructureDefinition &target) const override;
 	Persistent* findAttribute(const ReadableString &name) override;
@@ -50,6 +51,7 @@ public:
 	bool isContainer() const override;
 	void drawSelf(ImageRgbaU8& targetImage, const IRect &relativeLocation) override;
 	bool pointIsInside(const IVector2D& pixelPosition) override;
+	IVector2D getDesiredDimensions() override;
 };
 
 }

--- a/Source/DFPSR/gui/components/ListBox.h
+++ b/Source/DFPSR/gui/components/ListBox.h
@@ -34,8 +34,8 @@ class ListBox : public VisualComponent {
 PERSISTENT_DECLARATION(ListBox)
 public:
 	// Attributes
-	PersistentColor foreColor;
-	PersistentColor backColor;
+	PersistentColor backColor = PersistentColor(200, 200, 200);
+	PersistentColor foreColor = PersistentColor(0, 0, 0);
 	PersistentStringList list;
 	PersistentInteger selectedIndex; // Should always be inside of the list's 0..length-1 bound or zero.
 	void declareAttributes(StructureDefinition &target) const override;

--- a/Source/DFPSR/gui/components/Menu.cpp
+++ b/Source/DFPSR/gui/components/Menu.cpp
@@ -1,0 +1,266 @@
+﻿// zlib open source license
+//
+// Copyright (c) 2018 to 2023 David Forsgren Piuva
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 
+//    3. This notice may not be removed or altered from any source
+//    distribution.
+
+#include "Menu.h"
+
+using namespace dsr;
+
+PERSISTENT_DEFINITION(Menu)
+
+void Menu::declareAttributes(StructureDefinition &target) const {
+	VisualComponent::declareAttributes(target);
+	target.declareAttribute(U"BackColor");
+	target.declareAttribute(U"ForeColor");
+	target.declareAttribute(U"Text");
+	target.declareAttribute(U"Padding");
+	target.declareAttribute(U"Spacing");
+}
+
+Persistent* Menu::findAttribute(const ReadableString &name) {
+	if (string_caseInsensitiveMatch(name, U"Color") || string_caseInsensitiveMatch(name, U"BackColor")) {
+		// The short Color alias refers to the back color in Buttons, because most buttons use black text.
+		return &(this->backColor);
+	} else if (string_caseInsensitiveMatch(name, U"ForeColor")) {
+		return &(this->foreColor);
+	} else if (string_caseInsensitiveMatch(name, U"Text")) {
+		return &(this->text);
+	} else if (string_caseInsensitiveMatch(name, U"Padding")) {
+		return &(this->padding);
+	} else if (string_caseInsensitiveMatch(name, U"Spacing")) {
+		return &(this->spacing);
+	} else {
+		return VisualComponent::findAttribute(name);
+	}
+}
+
+Menu::Menu() {}
+
+bool Menu::isContainer() const {
+	return true;
+}
+
+static OrderedImageRgbaU8 generateHeadImage(Menu &menu, MediaMethod imageGenerator, int pressed, int width, int height, ColorRgbI32 backColor, ColorRgbI32 foreColor, const ReadableString &text, RasterFont font) {
+	// Create a scaled image
+	OrderedImageRgbaU8 result;
+ 	component_generateImage(menu.getTheme(), imageGenerator, width, height, backColor.red, backColor.green, backColor.blue, pressed)(result);
+	if (string_length(text) > 0) {
+		int left = (image_getWidth(result) - font_getLineWidth(font, text)) / 2;
+		int top = (image_getHeight(result) - font_getSize(font)) / 2;
+		if (pressed) {
+			top += 1;
+		}
+		font_printLine(result, font, text, IVector2D(left, top), ColorRgbaI32(foreColor, 255));
+	}
+	return result;
+}
+
+void Menu::generateGraphics() {
+	int headWidth = this->location.width();
+	int headHeight = this->location.height();
+	if (headWidth < 1) { headWidth = 1; }
+	if (headHeight < 1) { headHeight = 1; }
+	if (!this->hasImages) {
+		completeAssets();
+		this->imageUp = generateHeadImage(*this, this->headImageMethod, 0, headWidth, headHeight, this->backColor.value, this->foreColor.value, this->text.value, this->font);
+		this->imageDown = generateHeadImage(*this, this->headImageMethod, 0, headWidth, headHeight, ColorRgbI32(0, 0, 0), ColorRgbI32(255, 255, 255), this->text.value, this->font);
+		this->hasImages = true;
+	}
+}
+
+// Fill the listBackgroundImageMethod with a solid color
+void Menu::drawSelf(ImageRgbaU8& targetImage, const IRect &relativeLocation) {
+	this->generateGraphics();
+	draw_alphaFilter(targetImage, this->showingOverlay ? this->imageDown : this->imageUp, relativeLocation.left(), relativeLocation.top());
+}
+
+void Menu::generateBackground() {
+	if (!image_exists(this->listBackgroundImage)) {
+		int listWidth = this->overlayLocation.width();
+		int listHeight = this->overlayLocation.height();
+		if (listWidth < 1) { listWidth = 1; }
+		if (listHeight < 1) { listHeight = 1; }
+		component_generateImage(this->theme, this->listBackgroundImageMethod, listWidth, listHeight, this->backColor.value.red, this->backColor.value.green, this->backColor.value.blue)(this->listBackgroundImage);
+	}
+}
+
+void Menu::showOverlay() {
+	// Both showingOverlay and makeFocused are currently required for the overlay to be visible.
+	this->showingOverlay = true;
+	this->makeFocused();
+	IRect memberBound = this->children[0]->location;
+	for (int i = 1; i < this->getChildCount(); i++) {
+		memberBound = IRect::merge(memberBound, this->children[i]->location);
+	}
+	this->overlayLocation = memberBound.expanded(this->padding.value) + this->location.upperLeft();
+}
+
+bool Menu::managesChildren() {
+	return true;
+}
+
+bool Menu::pointIsInsideOfOverlay(const IVector2D& pixelPosition) {
+	return pixelPosition.x > this->overlayLocation.left() && pixelPosition.x < this->overlayLocation.right() && pixelPosition.y > this->overlayLocation.top() && pixelPosition.y < this->overlayLocation.bottom();
+}
+
+// TODO: Draw decorations using headImage.
+void Menu::drawOverlay(ImageRgbaU8& targetImage, const IVector2D &absoluteOffset) {
+	if (this->showingOverlay) {
+		this->generateBackground();
+		// TODO: Let the theme select between solid and alpha filtered drawing.
+		IVector2D overlayOffset = absoluteOffset + this->overlayLocation.upperLeft();
+		draw_copy(targetImage, this->listBackgroundImage, overlayOffset.x, overlayOffset.y);
+		for (int i = 0; i < this->getChildCount(); i++) {
+			this->children[i]->draw(targetImage, absoluteOffset + this->location.upperLeft());
+		}
+	}
+}
+
+void Menu::changedTheme(VisualTheme newTheme) {
+	this->headImageMethod = theme_getScalableImage(newTheme, this->subMenu ? U"MenuSub" : U"MenuTop");
+	this->listBackgroundImageMethod = theme_getScalableImage(newTheme, U"MenuList");
+	this->hasImages = false;
+}
+
+void Menu::completeAssets() {
+	if (this->headImageMethod.methodIndex == -1) {
+		// Work as a sub-menu if the direct parent is also a menu.
+		this->subMenu = this->parent != nullptr && dynamic_cast<Menu*>(this->parent) != nullptr;
+		this->headImageMethod = theme_getScalableImage(theme_getDefault(), this->subMenu ? U"MenuSub" : U"MenuTop");
+		this->listBackgroundImageMethod = theme_getScalableImage(theme_getDefault(), U"MenuList");
+	}
+	if (this->font.get() == nullptr) {
+		this->font = font_getDefault();
+	}
+}
+
+void Menu::changedLocation(const IRect &oldLocation, const IRect &newLocation) {
+	// If the component has changed dimensions then redraw the image
+	if (oldLocation.size() != newLocation.size()) {
+		this->hasImages = false;
+	}
+}
+
+void Menu::changedAttribute(const ReadableString &name) {
+	if (!string_caseInsensitiveMatch(name, U"Visible")) {
+		this->hasImages = false;
+	}
+}
+
+void Menu::lostFocus() {
+	// Hide the menu when losing focus.
+	this->showingOverlay = false;
+	// Erase the list image to save memory.
+	this->listBackgroundImage = OrderedImageRgbaU8();
+}
+
+void Menu::updateLocationEvent(const IRect& oldLocation, const IRect& newLocation) {	
+	int left = this->padding.value;
+	int top = this->padding.value;
+	int overlap = 3;
+	if (this->subMenu) {
+		left += newLocation.width() - overlap;
+	} else {
+		top += newLocation.height() - overlap;
+	}
+	int maxWidth = newLocation.width() - (this->padding.value * 2);
+	for (int i = 0; i < this->getChildCount(); i++) {
+		int width = this->children[i]->getDesiredDimensions().x;
+		if (maxWidth < width) maxWidth = width;
+	}
+	for (int i = 0; i < this->getChildCount(); i++) {
+		int height = this->children[i]->getDesiredDimensions().y;
+		this->children[i]->applyLayout(IRect(left, top, maxWidth, height));
+		top += height + this->spacing.value;
+	}
+}
+
+static void closeEntireMenu(VisualComponent* menu) {
+	while (menu->parent != nullptr) {
+		menu->showingOverlay = false;
+		menu = menu->parent;
+	}
+}
+
+void Menu::receiveMouseEvent(const MouseEvent& event) {
+	int childCount = this->getChildCount();
+	IVector2D positionFromParent = event.position;
+	MouseEvent localEvent = event;
+	localEvent.position -= this->location.upperLeft();
+	if (this->showingOverlay && this->pointIsInsideOfOverlay(event.position)) {
+		for (int i = childCount - 1; i >= 0; i--) {
+			if (this->children[i]->pointIsInside(localEvent.position)) {
+				this->children[i]->makeFocused();
+				MouseEvent childEvent = localEvent;
+				childEvent.position -= this->children[i]->location.upperLeft();
+				this->children[i]->sendMouseEvent(childEvent, true);
+				break;
+			}
+		}
+	} else if (this->pointIsInside(event.position)) {
+		if (childCount > 0) { // Has a list of members to open, toggle expansion when clicked.
+			if (this->subMenu) { // Menu within another menu.
+				// Hover to expand sub-menu's list.
+				if (event.mouseEventType == MouseEventType::MouseMove && !this->showingOverlay) {
+					this->showOverlay();
+				}
+			} else { // Top menu, which is usually placed in a toolbar.
+				bool toggleExpansion = false;
+				if (event.mouseEventType == MouseEventType::MouseDown) {
+					// Toggle expansion when headImageMethod is clicked.
+					toggleExpansion = true;
+				} else if (event.mouseEventType == MouseEventType::MouseMove && !this->showingOverlay) {
+					// Automatically expand hovered top-menus neighboring an opened top menu.
+					if (this->parent != nullptr) {
+						if (this->parent->focusComponent.get() != nullptr && this->parent->focusComponent->showingOverlay) {
+							toggleExpansion = true;
+						}
+					}
+				}
+				if (toggleExpansion) {
+					// Menu components with child members will toggle visibility for its list when pressed.
+					if (this->showingOverlay) {
+						closeEntireMenu(this);
+					} else {
+						this->showOverlay();
+					}
+				}
+			}
+		} else { // List item, because it has no children.
+			// Childless menu components are treated as menu items that can be clicked to perform an action and close the menu.
+			if (event.mouseEventType == MouseEventType::MouseDown) {
+				// Hide overlays all the way to root.
+				closeEntireMenu(this);
+				// Call the event assigned to this menu item.
+				this->callback_pressedEvent();
+			}
+		}
+		// Because the main body was interacted with, the mouse events are passed on.
+		VisualComponent::receiveMouseEvent(event);
+	}
+}
+
+IVector2D Menu::getDesiredDimensions() {
+	this->completeAssets();
+	int sizeAdder = this->padding.value * 2;
+	return IVector2D(font_getLineWidth(this->font, this->text.value) + sizeAdder, font_getSize(this->font) + sizeAdder);
+}

--- a/Source/DFPSR/gui/components/Menu.cpp
+++ b/Source/DFPSR/gui/components/Menu.cpp
@@ -69,6 +69,7 @@ static OrderedImageRgbaU8 generateHeadImage(Menu &menu, MediaMethod imageGenerat
 		if (pressed) {
 			top += 1;
 		}
+		// TODO: Mark sub-menus as expandable using a right facing triangle.
 		font_printLine(result, font, text, IVector2D(left, top), ColorRgbaI32(foreColor, 255));
 	}
 	return result;

--- a/Source/DFPSR/gui/components/Menu.h
+++ b/Source/DFPSR/gui/components/Menu.h
@@ -1,0 +1,79 @@
+﻿// zlib open source license
+//
+// Copyright (c) 2018 to 2023 David Forsgren Piuva
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 
+//    3. This notice may not be removed or altered from any source
+//    distribution.
+
+#ifndef DFPSR_GUI_COMPONENT_MENU
+#define DFPSR_GUI_COMPONENT_MENU
+
+#include "../VisualComponent.h"
+#include "../../api/fontAPI.h"
+
+namespace dsr {
+
+class Menu : public VisualComponent {
+PERSISTENT_DECLARATION(Menu)
+public:
+	// Attributes
+	PersistentColor backColor;
+	PersistentColor foreColor;
+	PersistentString text;
+	PersistentInteger padding = PersistentInteger(4); // Empty space around child components and its own text.
+	PersistentInteger spacing = PersistentInteger(2); // Empty space between child components.
+	void declareAttributes(StructureDefinition &target) const override;
+	Persistent* findAttribute(const ReadableString &name) override;
+private:
+	void completeAssets();
+	void generateGraphics();
+	void generateBackground();
+	MediaMethod headImageMethod, listBackgroundImageMethod;
+	OrderedImageRgbaU8 headImage, listBackgroundImage;
+	RasterFont font;
+	bool subMenu = false;
+	IRect overlayLocation; // Relative to the parent's location, just like its own location
+	// Generated
+	bool hasImages = false;
+	OrderedImageRgbaU8 imageUp;
+	OrderedImageRgbaU8 imageDown;
+public:
+	Menu();
+public:
+	bool isContainer() const override;
+	void drawSelf(ImageRgbaU8& targetImage, const IRect &relativeLocation) override;
+	void drawOverlay(ImageRgbaU8& targetImage, const IVector2D &absoluteOffset) override;
+	void changedTheme(VisualTheme newTheme) override;
+	void changedLocation(const IRect &oldLocation, const IRect &newLocation) override;
+	void changedAttribute(const ReadableString &name) override;
+	void updateLocationEvent(const IRect& oldLocation, const IRect& newLocation) override;
+	void receiveMouseEvent(const MouseEvent& event) override;
+	IVector2D getDesiredDimensions() override;
+	bool managesChildren() override;
+public:
+	// Helper functions for overlay projecting components.
+	void showOverlay();
+	void lostFocus() override;
+	bool pointIsInsideOfOverlay(const IVector2D& pixelPosition) override;
+};
+
+}
+
+#endif
+

--- a/Source/DFPSR/gui/components/Menu.h
+++ b/Source/DFPSR/gui/components/Menu.h
@@ -67,6 +67,8 @@ public:
 	IVector2D getDesiredDimensions() override;
 	bool managesChildren() override;
 public:
+	// Helper functions for decorations.
+	bool hasArrow();
 	// Helper functions for overlay projecting components.
 	void showOverlay();
 	void lostFocus() override;

--- a/Source/DFPSR/gui/components/Menu.h
+++ b/Source/DFPSR/gui/components/Menu.h
@@ -71,7 +71,7 @@ public:
 	bool hasArrow();
 	// Helper functions for overlay projecting components.
 	void createOverlay();
-	void stateChanged(ComponentState oldState, ComponentState newState) override;
+	void updateStateEvent(ComponentState oldState, ComponentState newState) override;
 	bool pointIsInsideOfOverlay(const IVector2D& pixelPosition) override;
 };
 

--- a/Source/DFPSR/gui/components/Menu.h
+++ b/Source/DFPSR/gui/components/Menu.h
@@ -33,8 +33,8 @@ class Menu : public VisualComponent {
 PERSISTENT_DECLARATION(Menu)
 public:
 	// Attributes
-	PersistentColor backColor;
-	PersistentColor foreColor;
+	PersistentColor backColor = PersistentColor(130, 130, 130);
+	PersistentColor foreColor = PersistentColor(0, 0, 0);
 	PersistentString text;
 	PersistentInteger padding = PersistentInteger(4); // Empty space around child components and its own text.
 	PersistentInteger spacing = PersistentInteger(2); // Empty space between child components.

--- a/Source/DFPSR/gui/components/Menu.h
+++ b/Source/DFPSR/gui/components/Menu.h
@@ -70,8 +70,8 @@ public:
 	// Helper functions for decorations.
 	bool hasArrow();
 	// Helper functions for overlay projecting components.
-	void showOverlay();
-	void lostFocus() override;
+	void createOverlay();
+	void stateChanged(ComponentState oldState, ComponentState newState) override;
 	bool pointIsInsideOfOverlay(const IVector2D& pixelPosition) override;
 };
 

--- a/Source/DFPSR/gui/components/Panel.h
+++ b/Source/DFPSR/gui/components/Panel.h
@@ -34,7 +34,7 @@ public:
 	// Attributes
 	PersistentBoolean solid; // If true, the panel itself will be drawn.
 	PersistentBoolean plain; // If true, a solid color will be drawn instead of a buffered image to save time and memory.
-	PersistentColor color; // The color being used when drawn is set to true.
+	PersistentColor color = PersistentColor(130, 130, 130); // The color being used when solid is set to true.
 	void declareAttributes(StructureDefinition &target) const override;
 	Persistent* findAttribute(const ReadableString &name) override;
 private:

--- a/Source/DFPSR/gui/components/TextBox.h
+++ b/Source/DFPSR/gui/components/TextBox.h
@@ -55,8 +55,8 @@ public:
 	void updateScrollRange();
 	void limitScrolling(bool keepBeamVisible);
 	// Attributes
-	PersistentColor foreColor;
-	PersistentColor backColor;
+	PersistentColor foreColor = PersistentColor(0, 0, 0);
+	PersistentColor backColor = PersistentColor(200, 200, 200);
 	PersistentString text;
 	PersistentBoolean multiLine;
 	int64_t borderX = 6; // Empty pixels left and right of text.

--- a/Source/DFPSR/gui/components/Toolbar.cpp
+++ b/Source/DFPSR/gui/components/Toolbar.cpp
@@ -108,8 +108,10 @@ void Toolbar::changedAttribute(const ReadableString &name) {
 }
 
 void Toolbar::updateLocationEvent(const IRect& oldLocation, const IRect& newLocation) {
-	// TODO: Find out if the toolbar is vertical or horizontal from its dimensions.
-	bool vertical = newLocation.width() < newLocation.height();
+	int widthStretch = this->region.right.getRatio() - this->region.left.getRatio();
+	int heightStretch = this->region.bottom.getRatio() - this->region.top.getRatio();
+	// Place members vertically if the toolbar mostly stretches vertically or if it has uniform stretch and is taller than wide.
+	bool vertical = (widthStretch < heightStretch) || ((widthStretch == heightStretch) && (newLocation.width() < newLocation.height()));
 	if (vertical) {
 		// TODO: Add scroll buttons on the sides if there is not enough space for all child components.
 		// Place each child component in order.

--- a/Source/DFPSR/gui/components/Toolbar.cpp
+++ b/Source/DFPSR/gui/components/Toolbar.cpp
@@ -1,0 +1,138 @@
+﻿// zlib open source license
+//
+// Copyright (c) 2018 to 2023 David Forsgren Piuva
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 
+//    3. This notice may not be removed or altered from any source
+//    distribution.
+
+#include "Toolbar.h"
+
+using namespace dsr;
+
+PERSISTENT_DEFINITION(Toolbar)
+
+void Toolbar::declareAttributes(StructureDefinition &target) const {
+	VisualComponent::declareAttributes(target);
+	target.declareAttribute(U"Solid");
+	target.declareAttribute(U"Plain");
+	target.declareAttribute(U"Color");
+	target.declareAttribute(U"Padding");
+	target.declareAttribute(U"Spacing");
+}
+
+Persistent* Toolbar::findAttribute(const ReadableString &name) {
+	if (string_caseInsensitiveMatch(name, U"Solid")) {
+		return &(this->solid);
+	} else if (string_caseInsensitiveMatch(name, U"Plain")) {
+		return &(this->plain);
+	} else if (string_caseInsensitiveMatch(name, U"Color") || string_caseInsensitiveMatch(name, U"BackColor")) {
+		// Both color and backcolor is accepted as names for the only color.
+		return &(this->color);
+	} else if (string_caseInsensitiveMatch(name, U"Padding")) {
+		return &(this->padding);
+	} else if (string_caseInsensitiveMatch(name, U"Spacing")) {
+		return &(this->spacing);
+	} else {
+		return VisualComponent::findAttribute(name);
+	}
+}
+
+Toolbar::Toolbar() {}
+
+bool Toolbar::isContainer() const {
+	return true;
+}
+
+void Toolbar::generateGraphics() {
+	int width = this->location.width();
+	int height = this->location.height();
+	if (width < 1) { width = 1; }
+	if (height < 1) { height = 1; }
+	if (!this->hasImages) {
+		completeAssets();
+		component_generateImage(this->theme, this->background, width, height, this->color.value.red, this->color.value.green, this->color.value.blue)(this->imageBackground);
+		this->hasImages = true;
+	}
+}
+
+// Fill the background with a solid color
+void Toolbar::drawSelf(ImageRgbaU8& targetImage, const IRect &relativeLocation) {
+	if (this->solid.value) {
+		if (this->plain.value) {
+			draw_rectangle(targetImage, relativeLocation, ColorRgbaI32(this->color.value, 255));
+		} else {
+			this->generateGraphics();
+			draw_copy(targetImage, this->imageBackground, relativeLocation.left(), relativeLocation.top());
+		}
+	}
+}
+
+void Toolbar::changedTheme(VisualTheme newTheme) {
+	this->background = theme_getScalableImage(newTheme, U"Toolbar");
+	this->hasImages = false;
+}
+
+void Toolbar::completeAssets() {
+	if (this->background.methodIndex == -1) {
+		this->background = theme_getScalableImage(theme_getDefault(), U"Toolbar");
+	}
+}
+
+void Toolbar::changedLocation(const IRect &oldLocation, const IRect &newLocation) {
+	// If the component has changed dimensions then redraw the image
+	if (oldLocation.size() != newLocation.size()) {
+		this->hasImages = false;
+	}
+}
+
+void Toolbar::changedAttribute(const ReadableString &name) {
+	if (!string_caseInsensitiveMatch(name, U"Visible")) {
+		this->hasImages = false;
+	}
+}
+
+void Toolbar::updateLocationEvent(const IRect& oldLocation, const IRect& newLocation) {
+	// TODO: Find out if the toolbar is vertical or horizontal from its dimensions.
+	bool vertical = newLocation.width() < newLocation.height();
+	if (vertical) {
+		// TODO: Add scroll buttons on the sides if there is not enough space for all child components.
+		// Place each child component in order.
+		//   Each child is created within a segmented region, but can choose to add more padding or limit its height for fine adjustments.
+		int left = this->padding.value;
+		int top = newLocation.top() + this->padding.value;
+		int width = newLocation.width() - (this->padding.value * 2);
+		for (int i = 0; i < this->getChildCount(); i++) {
+			int height = this->children[i]->getDesiredDimensions().y;
+			this->children[i]->applyLayout(IRect(left, top, width, height));
+			top += height + this->spacing.value;
+		}
+	} else {
+		// TODO: Add scroll buttons on the sides if there is not enough space for all child components.
+		// Place each child component in order.
+		//   Each child is created within a segmented region, but can choose to add more padding or limit its height for fine adjustments.
+		int left = newLocation.left() + this->padding.value;
+		int top = this->padding.value;
+		int height = newLocation.height() - (this->padding.value * 2);
+		for (int i = 0; i < this->getChildCount(); i++) {
+			int width = this->children[i]->getDesiredDimensions().x;
+			this->children[i]->applyLayout(IRect(left, top, width, height));
+			left += width + this->spacing.value;
+		}
+	}
+}

--- a/Source/DFPSR/gui/components/Toolbar.h
+++ b/Source/DFPSR/gui/components/Toolbar.h
@@ -34,7 +34,7 @@ public:
 	// Attributes
 	PersistentBoolean solid; // If true, the panel itself will be drawn.
 	PersistentBoolean plain; // If true, a solid color will be drawn instead of a buffered image to save time and memory.
-	PersistentColor color; // The color being used when drawn is set to true.
+	PersistentColor color = PersistentColor(130, 130, 130); // The color being used when drawn is set to true.
 	PersistentInteger padding = PersistentInteger(2); // Empty space around child components.
 	PersistentInteger spacing = PersistentInteger(3); // Empty space between child components.
 	// TODO: Start, center, end and fill alignment options.

--- a/Source/DFPSR/gui/components/Toolbar.h
+++ b/Source/DFPSR/gui/components/Toolbar.h
@@ -1,0 +1,63 @@
+﻿// zlib open source license
+//
+// Copyright (c) 2018 to 2023 David Forsgren Piuva
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 
+//    3. This notice may not be removed or altered from any source
+//    distribution.
+
+#ifndef DFPSR_GUI_COMPONENT_TOOLBAR
+#define DFPSR_GUI_COMPONENT_TOOLBAR
+
+#include "../VisualComponent.h"
+
+namespace dsr {
+
+class Toolbar : public VisualComponent {
+PERSISTENT_DECLARATION(Toolbar)
+public:
+	// Attributes
+	PersistentBoolean solid; // If true, the panel itself will be drawn.
+	PersistentBoolean plain; // If true, a solid color will be drawn instead of a buffered image to save time and memory.
+	PersistentColor color; // The color being used when drawn is set to true.
+	PersistentInteger padding; // Empty space around child components.
+	PersistentInteger spacing; // Empty space between child components.
+	void declareAttributes(StructureDefinition &target) const override;
+	Persistent* findAttribute(const ReadableString &name) override;
+private:
+	void completeAssets();
+	void generateGraphics();
+	MediaMethod background;
+	OrderedImageRgbaU8 imageBackground; // Alpha is copied to the target and should be 255
+	// Generated
+	bool hasImages = false;
+public:
+	Toolbar();
+public:
+	bool isContainer() const override;
+	void drawSelf(ImageRgbaU8& targetImage, const IRect &relativeLocation) override;
+	void changedTheme(VisualTheme newTheme) override;
+	void changedLocation(const IRect &oldLocation, const IRect &newLocation) override;
+	void changedAttribute(const ReadableString &name) override;
+	void updateLocationEvent(const IRect& oldLocation, const IRect& newLocation) override;
+};
+
+}
+
+#endif
+

--- a/Source/DFPSR/gui/components/Toolbar.h
+++ b/Source/DFPSR/gui/components/Toolbar.h
@@ -35,8 +35,9 @@ public:
 	PersistentBoolean solid; // If true, the panel itself will be drawn.
 	PersistentBoolean plain; // If true, a solid color will be drawn instead of a buffered image to save time and memory.
 	PersistentColor color; // The color being used when drawn is set to true.
-	PersistentInteger padding; // Empty space around child components.
-	PersistentInteger spacing; // Empty space between child components.
+	PersistentInteger padding = PersistentInteger(2); // Empty space around child components.
+	PersistentInteger spacing = PersistentInteger(3); // Empty space between child components.
+	// TODO: Start, center, end and fill alignment options.
 	void declareAttributes(StructureDefinition &target) const override;
 	Persistent* findAttribute(const ReadableString &name) override;
 private:

--- a/Source/DFPSR/persistent/atomic/PersistentColor.h
+++ b/Source/DFPSR/persistent/atomic/PersistentColor.h
@@ -36,6 +36,7 @@ public:
 public:
 	PersistentColor() : value(0, 0, 0) {}
 	explicit PersistentColor(ColorRgbI32 color) : value(color) {}
+	explicit PersistentColor(int red, int green, int blue) : value(ColorRgbI32(red, green, blue)) {}
 public:
 	virtual bool assignValue(const ReadableString &text, const ReadableString &fromPath) override;
 	virtual String& toStreamIndented(String& out, const ReadableString& indentation) const override;

--- a/Source/SDK/guiExample/media/interface.lof
+++ b/Source/SDK/guiExample/media/interface.lof
@@ -1,9 +1,105 @@
 ﻿Begin : Panel
 	Name = "mainPanel"
 	Solid = 0
-	Begin : Panel
+	Begin : Toolbar
 		Name = "menuBar"
-		Bottom = +50
+		Bottom = 50
+		Solid = 1
+		Begin : Menu
+			Name = "menuFile"
+			Text = "File"
+			Begin : Menu
+				Name = "menuNew"
+				Text = "New"
+			End
+			Begin : Menu
+				Name = "menuLoad"
+				Text = "Load"
+			End
+			Begin : Menu
+				Name = "menuSave"
+				Text = "Save"
+			End
+			Begin : Menu
+				Name = "menuExit"
+				Text = "Exit"
+			End
+		End
+		Begin : Menu
+			Name = "menuEdit"
+			Text = "Edit"
+			Begin : Menu
+				Name = "menuUndo"
+				Text = "Undo"
+			End
+			Begin : Menu
+				Name = "menuRedo"
+				Text = "Redo"
+				Begin : Menu
+					Name = "menuRedoAction"
+					Index = 0
+					Text = "Redo some thing you did recently"
+				End
+				Begin : Menu
+					Name = "menuRedoAction"
+					Index = 1
+					Text = "Redo some thing you undid and redid"
+				End
+			End
+			Begin : Menu
+				Name = "menuCut"
+				Text = "Cut"
+			End
+			Begin : Menu
+				Name = "menuCopy"
+				Text = "Copy"
+			End
+			Begin : Menu
+				Name = "menuPaste"
+				Text = "Paste"
+			End
+		End
+		Begin : Menu
+			Name = "menuHelp"
+			Text = "Help"
+			Begin : Menu
+				Name = "menuDocumentation"
+				Text = "Documentation"
+				Begin : Menu
+					Name = "menuChapter"
+					Index = 0
+					Text = "Getting started"
+				End
+				Begin : Menu
+					Name = "menuChapter"
+					Index = 1
+					Text = "Just filling out this dummy sub-menu"
+				End
+				Begin : Menu
+					Name = "menuChapter"
+					Index = 2
+					Text = "More nonsense options that don't do anything"
+				End
+				Begin : Menu
+					Name = "menuChapter"
+					Index = 3
+					Text = "Just to show how menus are created"
+				End
+			End
+			Begin : Menu
+				Name = "menuLegal"
+				Text = "Legal"
+			End
+			Begin : Menu
+				Name = "menuAbout"
+				Text = "About"
+			End
+		End
+	End
+	Begin : Panel
+		Name = "actionBar"
+		Top = 50
+		Bottom = 100
 		Solid = 1
 		Color = 180,180,180
 		Begin : TextBox
@@ -29,7 +125,7 @@
 	End
 	Begin : Panel
 		Name = "workspace"
-		Top = +50
+		Top = 100
 		Solid = 1
 		Color = 100,100,100
 		Begin : ListBox

--- a/Source/SDK/guiExample/media/interface.lof
+++ b/Source/SDK/guiExample/media/interface.lof
@@ -69,6 +69,26 @@
 					Name = "menuChapter"
 					Index = 0
 					Text = "Getting started"
+					Begin : Menu
+						Name = "menuChapterStarted"
+						Index = 0
+						Text = "Why you should want to get started"
+					End
+					Begin : Menu
+						Name = "menuChapterStarted"
+						Index = 1
+						Text = "Why do you want to get started"
+					End
+					Begin : Menu
+						Name = "menuChapterStarted"
+						Index = 2
+						Text = "You do not want to get started"
+						Begin : Menu
+							Name = "menuChapterStarted"
+							Index = 3
+							Text = "It's just a mockup application"
+						End
+					End
 				End
 				Begin : Menu
 					Name = "menuChapter"


### PR DESCRIPTION
Created an overlay system that lets any VisualComponent draw things directly to the full canvas on top of other components. Also made a virtual function for disable automatic rendering and interaction with child components, so that one can render them within overlays or simply hide them.

Toolbar aligns child components automatically without having to specify any locations for them. Child components tell which minimum size they need to be usable. The Toolbar will detect automatically if it is vertical or horizontal, based on which dimension stretches the most from parent resizing, or just the length if one does not stretch more than the other.

Menu can be placed in a Toolbar, another Menu or any other container. Any component can be placed within a menu, just like they can be placed within a toolbar, but some types are harder to figure out a suitable reserved space for (might improve with more ideas). The same Menu component can be used for top menus (non-menu parent), sub-menus (menu parent), and menu items (contains no components) with fully automatic detection of what it should act as.

sendMouseEvent changed from parent space coordinates to local space, to make debugging easier by checking that a cursor over the upper left corner gives zeroes, but this might later be changed back if it becomes too confusing. VisualComponent got major refactoring and it is now allowed to move the root panel, while still not recommended because you can just create a non-solid panel.