### PR TITLE
Improved min and max functions

### DIFF
--- a/Source/DFPSR/gui/DsrWindow.cpp
+++ b/Source/DFPSR/gui/DsrWindow.cpp
@@ -177,11 +177,11 @@ int DsrWindow::getInnerHeight() {
 }
 
 int DsrWindow::getCanvasWidth() {
-	return std::max(1, this->innerWidth / this->pixelScale);
+	return max(1, this->innerWidth / this->pixelScale);
 }
 
 int DsrWindow::getCanvasHeight() {
-	return std::max(1, this->innerHeight / this->pixelScale);
+	return max(1, this->innerHeight / this->pixelScale);
 }
 
 AlignedImageF32 DsrWindow::getDepthBuffer() {

--- a/Source/DFPSR/gui/FlexRegion.h
+++ b/Source/DFPSR/gui/FlexRegion.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include "../math/IVector.h"
 #include "../math/IRect.h"
+#include "../math/scalar.h"
 #include "../api/stringAPI.h"
 #include "../persistent/ClassFactory.h"
 
@@ -39,7 +40,7 @@ private:
 	int32_t offset = 0; // +- offset
 public:
 	FlexValue() {}
-	FlexValue(int ratio, int offset) : ratio(std::min(std::max(0, ratio), 100)), offset(offset) {}
+	FlexValue(int ratio, int offset) : ratio(min(max(0, ratio), 100)), offset(offset) {}
 public:
 	bool assignValue(const ReadableString &text, const ReadableString &fromPath) override;
 	String& toStreamIndented(String& out, const ReadableString& indentation) const override;

--- a/Source/DFPSR/math/scalar.h
+++ b/Source/DFPSR/math/scalar.h
@@ -1,6 +1,6 @@
 ﻿// zlib open source license
 //
-// Copyright (c) 2017 to 2019 David Forsgren Piuva
+// Copyright (c) 2017 to 2023 David Forsgren Piuva
 // 
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -27,6 +27,28 @@
 #include <cmath>
 
 namespace dsr {
+
+// A minimum function that can take more than two arguments.
+// Post-condition: Returns the smallest of all given values, which must be comparable using the < operator and have the same type.
+template <typename T>
+inline T min(const T &a, const T &b) {
+	return (a < b) ? a : b;
+}
+template <typename T, typename... TAIL>
+inline T min(const T &a, const T &b, TAIL... tail) {
+	return min(min(a, b), tail...);
+}
+
+// A maximum function that can take more than two arguments.
+// Post-condition: Returns the largest of all given values, which must be comparable using the > operator and have the same type.
+template <typename T>
+inline T max(const T &a, const T &b) {
+	return (a > b) ? a : b;
+}
+template <typename T, typename... TAIL>
+inline T max(const T &a, const T &b, TAIL... tail) {
+	return max(max(a, b), tail...);
+}
 
 // Preconditions:
 //   0 <= a <= 255

--- a/Source/DFPSR/render/ITriangle2D.cpp
+++ b/Source/DFPSR/render/ITriangle2D.cpp
@@ -35,10 +35,10 @@ IRect dsr::getTriangleBound(LVector2D a, LVector2D b, LVector2D c) {
 	int32_t rY2 = (b.y + constants::unitsPerHalfPixel) / constants::unitsPerPixel;
 	int32_t rX3 = (c.x + constants::unitsPerHalfPixel) / constants::unitsPerPixel;
 	int32_t rY3 = (c.y + constants::unitsPerHalfPixel) / constants::unitsPerPixel;
-	int leftBound = std::min(std::min(rX1, rX2), rX3) - 1;
-	int topBound = std::min(std::min(rY1, rY2), rY3) - 1;
-	int rightBound = std::max(std::max(rX1, rX2), rX3) + 1;
-	int bottomBound = std::max(std::max(rY1, rY2), rY3) + 1;
+	int leftBound = min(rX1, rX2, rX3) - 1;
+	int topBound = min(rY1, rY2, rY3) - 1;
+	int rightBound = max(rX1, rX2, rX3) + 1;
+	int bottomBound = max(rY1, rY2, rY3) + 1;
 	return IRect(leftBound, topBound, rightBound - leftBound, bottomBound - topBound);
 }
 
@@ -60,11 +60,11 @@ bool ITriangle2D::isFrontfacing() const {
 }
 
 inline static void cutRight(int32_t& rightBound, int32_t value) {
-	rightBound = std::min(rightBound, value);
+	rightBound = min(rightBound, value);
 }
 
 inline static void cutLeft(int32_t& leftBound, int32_t value) {
-	leftBound = std::max(leftBound, value);
+	leftBound = max(leftBound, value);
 }
 
 IRect ITriangle2D::getAlignedRasterBound(const IRect& clipBound, int alignX, int alignY) const {
@@ -119,7 +119,7 @@ static void cutConvexEdge(const LVector2D& startPoint, const LVector2D& endPoint
 			for (int32_t y = topBound; y < bottomBound; y++) {
 				int32_t rowIndex = y - topBound;
 				// Find the highest x where offsetX * x > limit
-				int32_t leftSide = std::min(std::max(leftBound, (int32_t)((limit + 1) / offsetX + 1)), rightBound);
+				int32_t leftSide = min(max(leftBound, (int32_t)((limit + 1) / offsetX + 1)), rightBound);
 				cutLeft(rows[rowIndex].left, leftSide);
 				limit -= offsetY;
 			}
@@ -127,7 +127,7 @@ static void cutConvexEdge(const LVector2D& startPoint, const LVector2D& endPoint
 			for (int32_t y = topBound; y < bottomBound; y++) {
 				int32_t rowIndex = y - topBound;
 				// Find the lowest x where offsetX * x > limit
-				int32_t rightSide = std::min(std::max(leftBound, (int32_t)(limit / offsetX + 1)), rightBound);
+				int32_t rightSide = min(max(leftBound, (int32_t)(limit / offsetX + 1)), rightBound);
 				cutRight(rows[rowIndex].right, rightSide);
 				limit -= offsetY;
 			}

--- a/Source/DFPSR/render/shader/Shader.cpp
+++ b/Source/DFPSR/render/shader/Shader.cpp
@@ -261,10 +261,10 @@ inline static void fillShapeSuper(const Shader& shader, ImageRgbaU8Impl *colorBu
 		int y2 = y1 + 1;
 		RowInterval upperRow = shape.rows[y1 - shape.startRow];
 		RowInterval lowerRow = shape.rows[y2 - shape.startRow];
-		int outerStart = std::min(upperRow.left, lowerRow.left);
-		int outerEnd = std::max(upperRow.right, lowerRow.right);
-		int innerStart = std::max(upperRow.left, lowerRow.left);
-		int innerEnd = std::min(upperRow.right, lowerRow.right);
+		int outerStart = min(upperRow.left, lowerRow.left);
+		int outerEnd = max(upperRow.right, lowerRow.right);
+		int innerStart = max(upperRow.left, lowerRow.left);
+		int innerEnd = min(upperRow.right, lowerRow.right);
 		// Round exclusive intervals to multiples of two pixels
 		int outerBlockStart = roundDownEven(outerStart);
 		int outerBlockEnd = roundUpEven(outerEnd);

--- a/Source/DFPSR/render/shader/shaderMethods.h
+++ b/Source/DFPSR/render/shader/shaderMethods.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include "../../math/FVector.h"
+#include "../../math/scalar.h"
 #include "../../base/simd3D.h"
 #include "../../image/ImageRgbaU8.h"
 #include "shaderTypes.h"
@@ -119,9 +120,9 @@ namespace shaderMethods {
 		float offsetUY = fabs(ua.x - ua.z);
 		float offsetVX = fabs(va.x - va.y);
 		float offsetVY = fabs(va.x - va.z);
-		float offsetU = std::max(offsetUX, offsetUY) * source->width;
-		float offsetV = std::max(offsetVX, offsetVY) * source->height;
-		float offset = std::max(offsetU, offsetV);
+		float offsetU = max(offsetUX, offsetUY) * source->width;
+		float offsetV = max(offsetVX, offsetVY) * source->height;
+		float offset = max(offsetU, offsetV);
 
 		// This log2 approximation has to be adapted if the number of mip levels changes.
 		static_assert(MIP_BIN_COUNT == 5, "Changing MIP_BIN_COUNT must also adapt shaderMethods::getMipLevelOffset");


### PR DESCRIPTION
To reduce mixed namespaces and allow writing **max(a, b, c, d, e)** instead of **std::max(std::max(std::max(std::max(a, b), c), d), e)**.

The two argument functions are only applied after non-template functions in simd.h did not match (according to C++ standard for resolving overloaded functions). The tail recursive  functions should be able to call min and max written for specific types that have intrinsic functions.