### PR TITLE
Relative padding for isometric camera frustums

### DIFF
--- a/Source/DFPSR/render/Camera.h
+++ b/Source/DFPSR/render/Camera.h
@@ -46,10 +46,10 @@ public:
 	// Orthogonal view frustum in camera space
 	ViewFrustum(float halfWidth, float halfHeight) : planeCount(4) {
 		// Sides
-		planes[0] = FPlane3D(FVector3D(1.0f, 0.0f, 0.0f), halfWidth + 0.1f);
-		planes[1] = FPlane3D(FVector3D(-1.0f, 0.0f, 0.0f), halfWidth + 0.1f);
-		planes[2] = FPlane3D(FVector3D(0.0f, 1.0f, 0.0f), halfHeight + 0.1f);
-		planes[3] = FPlane3D(FVector3D(0.0f, -1.0f, 0.0f), halfHeight + 0.1f);
+		planes[0] = FPlane3D(FVector3D(1.0f, 0.0f, 0.0f), halfWidth * 1.01);
+		planes[1] = FPlane3D(FVector3D(-1.0f, 0.0f, 0.0f), halfWidth * 1.01);
+		planes[2] = FPlane3D(FVector3D(0.0f, 1.0f, 0.0f), halfHeight * 1.01);
+		planes[3] = FPlane3D(FVector3D(0.0f, -1.0f, 0.0f), halfHeight * 1.01);
 	}
 	// Perspective view frustum in camera space
 	ViewFrustum(float nearClip, float farClip, float widthSlope, float heightSlope) : planeCount(6) {

--- a/Source/DFPSR/render/renderCore.cpp
+++ b/Source/DFPSR/render/renderCore.cpp
@@ -50,9 +50,21 @@ public:
 	}
 };
 
+// Returns 0 when value = a
+// Returns 0.5 when value = (a + b) / 2
+// Returns 1 when value = b
+static float inverseLerp(float a, float b, float value) {
+	float c = b - a;
+	if (c == 0.0f) {
+		return 0.5f;
+	} else {
+		return (value - a) / c;
+	}
+}
+
+static const int maxPoints = 9; // If a triangle starts with 3 points and each of 6 planes in the view frustum can add one point each then the maximum is 9 points
 class ClippedTriangle {
 private:
-	static const int maxPoints = 9; // If a triangle starts with 3 points and each of 6 planes in the view frustum can add one point each then the maximum is 9 points
 	int vertexCount = 0;
 public:
 	int getVertexCount() {
@@ -91,17 +103,6 @@ public:
 	}
 	void deleteAll() {
 		this->vertexCount = 0;
-	}
-	// Returns 0 when value = a
-	// Returns 0.5 when value = (a + b) / 2
-	// Returns 1 when value = b
-	static float inverseLerp(float a, float b, float value) {
-		float c = b - a;
-		if (c == 0.0f) {
-			return 0.5f;
-		} else {
-			return (value - a) / c;
-		}
 	}
 	// Cut away parts of the triangle that are on the positive side of the plane
 	void clip(const FPlane3D &plane) {


### PR DESCRIPTION
Because the padding for isometric frustums were in absolute units, zooming in to something extremely small scales caused integer overflows in triangle rasterization, because 0.1 units suddenly corresponded to billions of pixels on the screen. With the new relative padding of 1%, one should be able to zoom in to microscopic levels without getting broken triangles.