### PR TITLE
Custom error handling

### DIFF
--- a/Source/DFPSR/gui/VisualComponent.cpp
+++ b/Source/DFPSR/gui/VisualComponent.cpp
@@ -248,11 +248,11 @@ void VisualComponent::drawOverlay(ImageRgbaU8& targetImage, const IVector2D &abs
 // Manual use with the correct type
 void VisualComponent::addChildComponent(std::shared_ptr<VisualComponent> child) {
 	if (!this->isContainer()) {
-		throwError(U"Cannot attach a child to a non-container parent component!\n");
+		sendWarning(U"Cannot attach a child to a non-container parent component!\n");
 	} else if (child.get() == this) {
-		throwError(U"Cannot attach a component to itself!\n");
+		sendWarning(U"Cannot attach a component to itself!\n");
 	} else if (child->hasChild(this)) {
-		throwError(U"Cannot attach to its own parent as a child component!\n");
+		sendWarning(U"Cannot attach to its own parent as a child component!\n");
 	} else {
 		// Remove from any previous parent
 		child->detachFromParent();
@@ -643,7 +643,7 @@ VisualTheme VisualComponent::getTheme() const {
 void VisualComponent::changedTheme(VisualTheme newTheme) {}
 
 String VisualComponent::call(const ReadableString &methodName, const ReadableString &arguments) {
-	throwError("Unimplemented custom call received");
+	sendWarning("Unimplemented custom call received");
 	return U"";
 }
 
@@ -673,8 +673,8 @@ MediaResult dsr::component_generateImage(VisualTheme theme, MediaMethod &method,
 			// Assigned by theme_assignMediaMachineArguments.
 		} else {
 			// TODO: Ask the theme for the argument using a specified style class for variations between different types of buttons, checkboxes, panels, et cetera.
-			//       Throw an exception if the theme did not provide an input argument to its own media function.
-			throwError(U"Unhandled setting \"", argumentName, U"\" requested by the media method \"", machine_getMethodName(machine, methodIndex), U"\" in the visual theme!\n");
+			//       Send a warning if the theme did not provide an input argument to its own media function.
+			sendWarning(U"Unhandled setting \"", argumentName, U"\" requested by the media method \"", machine_getMethodName(machine, methodIndex), U"\" in the visual theme!\n");
 		}
 	});
 }

--- a/Source/soundManagers/AlsaSound.cpp
+++ b/Source/soundManagers/AlsaSound.cpp
@@ -38,35 +38,42 @@ bool sound_streamToSpeakers(int channels, int sampleRate, std::function<bool(Saf
 	int errorCode;
 	if ((errorCode = snd_pcm_open(&pcm, "default", SND_PCM_STREAM_PLAYBACK, 0)) < 0) {
 		terminateSound();
-		throwError("Cannot open sound device. (", snd_strerror(errorCode), ")\n");
+		sendWarning("Cannot open sound device. (", snd_strerror(errorCode), ")\n");
+		return false;
 	}
 	snd_pcm_hw_params_t *hardwareParameters;
 	snd_pcm_hw_params_alloca(&hardwareParameters);
 	snd_pcm_hw_params_any(pcm, hardwareParameters);
 	if ((errorCode = snd_pcm_hw_params_set_access(pcm, hardwareParameters, SND_PCM_ACCESS_RW_INTERLEAVED)) < 0) {
 		terminateSound();
-		throwError("Failed to select interleaved sound. (", snd_strerror(errorCode), ")\n");
+		sendWarning("Failed to select interleaved sound. (", snd_strerror(errorCode), ")\n");
+		return false;
 	}
 	if ((errorCode = snd_pcm_hw_params_set_format(pcm, hardwareParameters, SND_PCM_FORMAT_S16_LE)) < 0) {
 		terminateSound();
-		throwError("Failed to select sound format. (", snd_strerror(errorCode), ")\n");
+		sendWarning("Failed to select sound format. (", snd_strerror(errorCode), ")\n");
+		return false;
 	}
 	if ((errorCode = snd_pcm_hw_params_set_channels(pcm, hardwareParameters, channels)) < 0) {
 		terminateSound();
-		throwError("Failed to select channel count. (", snd_strerror(errorCode), ")\n");
+		sendWarning("Failed to select channel count. (", snd_strerror(errorCode), ")\n");
+		return false;
 	}
 	if ((errorCode = snd_pcm_hw_params_set_buffer_size(pcm, hardwareParameters, 2048)) < 0) {
 		terminateSound();
-		throwError("Failed to select buffer size. (", snd_strerror(errorCode), ")\n");
+		sendWarning("Failed to select buffer size. (", snd_strerror(errorCode), ")\n");
+		return false;
 	}
 	uint rate = sampleRate;
 	if ((errorCode = snd_pcm_hw_params_set_rate_near(pcm, hardwareParameters, &rate, 0)) < 0) {
 		terminateSound();
-		throwError("Failed to select approximate sample rate. (", snd_strerror(errorCode), ")\n");
+		sendWarning("Failed to select approximate sample rate. (", snd_strerror(errorCode), ")\n");
+		return false;
 	}
 	if ((errorCode = snd_pcm_hw_params(pcm, hardwareParameters)) < 0) {
 		terminateSound();
-		throwError("Failed to select hardware parameters. (", snd_strerror(errorCode), ")\n");
+		sendWarning("Failed to select hardware parameters. (", snd_strerror(errorCode), ")\n");
+		return false;
 	}
 	// Allocate a buffer for sending data to speakers
 	snd_pcm_uframes_t samplesPerChannel;

--- a/Source/windowManagers/NoWindow.cpp
+++ b/Source/windowManagers/NoWindow.cpp
@@ -3,7 +3,7 @@
 #include "../DFPSR/api/stringAPI.h"
 
 std::shared_ptr<dsr::BackendWindow> createBackendWindow(const dsr::String& title, int width, int height) {
-	dsr::throwError("Tried to create a DsrWindow without a window manager selected!\n");
+	dsr::sendWarning("Tried to create a DsrWindow without a window manager selected!\n");
 	return std::shared_ptr<dsr::BackendWindow>();
 }
 

--- a/Source/windowManagers/X11Window.cpp
+++ b/Source/windowManagers/X11Window.cpp
@@ -705,7 +705,7 @@ std::shared_ptr<dsr::BackendWindow> createBackendWindow(const dsr::String& title
 		auto backend = std::make_shared<X11Window>(title, width, height);
 		return std::dynamic_pointer_cast<dsr::BackendWindow>(backend);
 	} else {
-		dsr::printText("No display detected. Aborting X11 window creation.\n");
+		dsr::sendWarning("No display detected. Aborting X11 window creation.\n");
 		return std::shared_ptr<dsr::BackendWindow>();
 	}
 }


### PR DESCRIPTION
All printing to the terminal can now be redirected to log files or be printed directly to the graphical window.

Errors must at least throw an exception, because errors are used when the following code would cause severe damage or a flood of more error messages if not aborted.

Tested it in the GUI example program, but more testing is needed.