### PR TITLE
Implemented copy and paste on MS-Windows

### DIFF
--- a/Source/DFPSR/History.txt
+++ b/Source/DFPSR/History.txt
@@ -5,7 +5,25 @@ There are plans to create an automatic refactoring tool built into the Builder b
 
 Changes since version 0.1.0
 	* simdExtra.h was removed, because such a low depth of abstraction would risk making the code slower from not fitting well with future SIMD extensions.
+		The more features you add to the badly defined extra feature set, the less systems it will work on, until it is just a slower version of specific instruction sets.
 		On missing header when including simdExtra.h:
 			Replace 'simdExtra.h' with 'simd.h' to make it compile.
 			Remove any duplicate includes of simd.h to clean up your code.
 			Remove all code within '#ifdef USE_SIMD_EXTRA' or '#if defined USE_SIMD_EXTRA' to clean up your code.
+	* Left and right sides of control, shift and alt keys were merged.
+		Because MS-Windows allow using control, shift and alt of undefined side.
+			This caused copying and pasting of text to fail when I tested on a different keyboard,
+			  because it was neither left nor right control, just control.
+			Adding a third case would not solve the bug in applications using this library,
+			  because checks for left or right would still fail.
+			Forcing unknown sides to one side would cause new bugs when someone connects different actions to left and right sides.
+			The only resaonable bugfix was to merge left and right sides into the same keys.
+		On missing DsrKey:
+			Replace 'DsrKey_LeftControl' with 'DsrKey_Control'
+			Replace 'DsrKey_RightControl' with 'DsrKey_Control'
+			Replace 'DsrKey_LeftShift' with 'DsrKey_Shift'
+			Replace 'DsrKey_RightShift' with 'DsrKey_Shift'
+			Replace 'DsrKey_LeftAlt' with 'DsrKey_Alt'
+			Replace 'DsrKey_RightAlt' with 'DsrKey_Alt'
+			Merge any uplicated checks for left or right versions to clean up your code.
+			Rethink the design if you relied on distinguishing between left and right control, shift or alt.

--- a/Source/DFPSR/api/guiAPI.cpp
+++ b/Source/DFPSR/api/guiAPI.cpp
@@ -508,12 +508,13 @@ String dsr::window_getTitle(Window& window) {
 	MUST_EXIST(window, window_getTitle);
 	return window->backend->getTitle();
 }
+
 String window_loadFromClipboard(Window& window, double timeoutInSeconds) {
 	MUST_EXIST(window, window_loadFromClipboard);
 	return window->backend->loadFromClipboard(timeoutInSeconds);
 }
 
-void window_saveToClipboard(Window& window, const ReadableString &text) {
+void window_saveToClipboard(Window& window, const ReadableString &text, double timeoutInSeconds) {
 	MUST_EXIST(window, window_saveToClipboard);
-	window->backend->saveToClipboard(text);
+	window->backend->saveToClipboard(text, timeoutInSeconds);
 }

--- a/Source/DFPSR/api/guiAPI.cpp
+++ b/Source/DFPSR/api/guiAPI.cpp
@@ -508,9 +508,9 @@ String dsr::window_getTitle(Window& window) {
 	MUST_EXIST(window, window_getTitle);
 	return window->backend->getTitle();
 }
-String window_loadFromClipboard(Window& window, int64_t timeoutInMilliseconds) {
+String window_loadFromClipboard(Window& window, double timeoutInSeconds) {
 	MUST_EXIST(window, window_loadFromClipboard);
-	return window->backend->loadFromClipboard(timeoutInMilliseconds);
+	return window->backend->loadFromClipboard(timeoutInSeconds);
 }
 
 void window_saveToClipboard(Window& window, const ReadableString &text) {

--- a/Source/DFPSR/api/guiAPI.cpp
+++ b/Source/DFPSR/api/guiAPI.cpp
@@ -498,3 +498,13 @@ void dsr::window_applyTheme(const Window& window, const VisualTheme& theme) {
 	MUST_EXIST(theme, window_applyTheme);
 	window->applyTheme(theme);
 }
+
+void dsr::window_setTitle(Window& window, const dsr::String& title) {
+	MUST_EXIST(window, window_setTitle);
+	window->backend->setTitle(title);
+}
+
+String dsr::window_getTitle(Window& window) {
+	MUST_EXIST(window, window_getTitle);
+	return window->backend->getTitle();
+}

--- a/Source/DFPSR/api/guiAPI.cpp
+++ b/Source/DFPSR/api/guiAPI.cpp
@@ -508,3 +508,12 @@ String dsr::window_getTitle(Window& window) {
 	MUST_EXIST(window, window_getTitle);
 	return window->backend->getTitle();
 }
+String window_loadFromClipboard(Window& window, int64_t timeoutInMilliseconds) {
+	MUST_EXIST(window, window_loadFromClipboard);
+	return window->backend->loadFromClipboard(timeoutInMilliseconds);
+}
+
+void window_saveToClipboard(Window& window, const ReadableString &text) {
+	MUST_EXIST(window, window_saveToClipboard);
+	window->backend->saveToClipboard(text);
+}

--- a/Source/DFPSR/api/guiAPI.h
+++ b/Source/DFPSR/api/guiAPI.h
@@ -46,8 +46,14 @@ namespace dsr {
 	// If the game starts in full screen, this constructor should be used instead.
 	//   Otherwise the canvas may ask for the window's dimensions while the system still keeps the old dimensions due to delays.
 	Window window_create_fullscreen(const dsr::String& title);
-	// Returns true iff the window exists
+	// Returns true iff the window exists.
 	bool window_exists(const Window& window);
+
+// Set window title
+	// Assigns the window's title.
+	void window_setTitle(Window& window, const dsr::String& title);
+	// Returns the window's title.
+	String window_getTitle(Window& window);
 
 // Layout files
 	// Loading an interface by parsing a layout file's content, with any external resources loaded relative to fromPath.
@@ -126,6 +132,8 @@ namespace dsr {
 	//   Just like when handling a window resize, this will replace the canvas and depth buffer.
 	//     Any old handles to canvas and depth buffer will become useless, so fetch new image handles from the window to avoid black flickering.
 	void window_setPixelScale(const Window& window, int scale);
+
+// Cursor
 	// Sets the cursor visibility for window, hiding if visible is false and showing if visible is true.
 	// Returns true on success and false on failure.
 	bool window_setCursorVisibility(const Window& window, bool visible);

--- a/Source/DFPSR/api/guiAPI.h
+++ b/Source/DFPSR/api/guiAPI.h
@@ -64,7 +64,7 @@ namespace dsr {
 	String window_loadFromClipboard(Window& window, double timeoutInSeconds);
 	// Stores the text argument to an internal or extenal clipboard.
 	//   The internal clipboard within the application is used when the system specific backend has not implemented clipboard access.
-	void window_saveToClipboard(Window& window, const ReadableString &text);
+	void window_saveToClipboard(Window& window, const ReadableString &text, double timeoutInSeconds);
 
 // Layout files
 	// Loading an interface by parsing a layout file's content, with any external resources loaded relative to fromPath.

--- a/Source/DFPSR/api/guiAPI.h
+++ b/Source/DFPSR/api/guiAPI.h
@@ -55,6 +55,17 @@ namespace dsr {
 	// Returns the window's title.
 	String window_getTitle(Window& window);
 
+// Clipboard
+	// Most operating systems require that a window is associated with each request to access the clipboard.
+	//   This allow anti-virus software to see the user consent for accessing the clipboard,
+	//   because a key combination commonly associated with pasting text was pressed before the request was made.
+	// Returns content from an internal or extenal clipboard.
+	//   The internal clipboard within the application is used when the system specific backend has not implemented clipboard access.
+	String window_loadFromClipboard(Window& window, int64_t timeoutInMilliseconds);
+	// Stores the text argument to an internal or extenal clipboard.
+	//   The internal clipboard within the application is used when the system specific backend has not implemented clipboard access.
+	void window_saveToClipboard(Window& window, const ReadableString &text);
+
 // Layout files
 	// Loading an interface by parsing a layout file's content, with any external resources loaded relative to fromPath.
 	//   Embedded images do not count as external resources, but file paths need fromPath in order to know from where they will be loaded.

--- a/Source/DFPSR/api/guiAPI.h
+++ b/Source/DFPSR/api/guiAPI.h
@@ -61,7 +61,7 @@ namespace dsr {
 	//   because a key combination commonly associated with pasting text was pressed before the request was made.
 	// Returns content from an internal or extenal clipboard.
 	//   The internal clipboard within the application is used when the system specific backend has not implemented clipboard access.
-	String window_loadFromClipboard(Window& window, int64_t timeoutInMilliseconds);
+	String window_loadFromClipboard(Window& window, double timeoutInSeconds);
 	// Stores the text argument to an internal or extenal clipboard.
 	//   The internal clipboard within the application is used when the system specific backend has not implemented clipboard access.
 	void window_saveToClipboard(Window& window, const ReadableString &text);

--- a/Source/DFPSR/gui/BackendWindow.cpp
+++ b/Source/DFPSR/gui/BackendWindow.cpp
@@ -28,7 +28,7 @@ using namespace dsr;
 // Used when access to the external clipboard is not implemented.
 static String backupClipboard;
 
-ReadableString BackendWindow::loadFromClipboard(int64_t timeoutInMilliseconds) {
+ReadableString BackendWindow::loadFromClipboard(double timeoutInSeconds) {
 	sendWarning(U"loadFromClipboard is not implemented! Simulating clipboard using a variable within the same application.");
 	return backupClipboard;
 }

--- a/Source/DFPSR/gui/BackendWindow.cpp
+++ b/Source/DFPSR/gui/BackendWindow.cpp
@@ -25,6 +25,19 @@
 
 using namespace dsr;
 
+// Used when access to the external clipboard is not implemented.
+static String backupClipboard;
+
+ReadableString BackendWindow::loadFromClipboard(int64_t timeoutInMilliseconds) {
+	sendWarning(U"loadFromClipboard is not implemented! Simulating clipboard using a variable within the same application.");
+	return backupClipboard;
+}
+
+void BackendWindow::saveToClipboard(const ReadableString &text) {
+	sendWarning(U"saveToClipboard is not implemented! Simulating clipboard using a variable within the same application.");
+	backupClipboard = text;
+}
+
 bool BackendWindow::executeEvents() {
 	bool executedEvent = false;
 	this->prefetchEvents();

--- a/Source/DFPSR/gui/BackendWindow.cpp
+++ b/Source/DFPSR/gui/BackendWindow.cpp
@@ -64,7 +64,7 @@ bool BackendWindow::executeEvents() {
 				if (wEvent->windowEventType == WindowEventType::Close) {
 					this->callback_closeEvent();
 				} else if (wEvent->windowEventType == WindowEventType::Redraw) {
-					this->showCanvas();
+					//this->showCanvas();
 				}
 			}
 		}

--- a/Source/DFPSR/gui/BackendWindow.cpp
+++ b/Source/DFPSR/gui/BackendWindow.cpp
@@ -33,7 +33,7 @@ ReadableString BackendWindow::loadFromClipboard(double timeoutInSeconds) {
 	return backupClipboard;
 }
 
-void BackendWindow::saveToClipboard(const ReadableString &text) {
+void BackendWindow::saveToClipboard(const ReadableString &text, double timeoutInSeconds) {
 	sendWarning(U"saveToClipboard is not implemented! Simulating clipboard using a variable within the same application.");
 	backupClipboard = text;
 }

--- a/Source/DFPSR/gui/BackendWindow.h
+++ b/Source/DFPSR/gui/BackendWindow.h
@@ -93,7 +93,7 @@ public:
 	// Load from the clipboard, waiting at most timeoutInMilliseconds milliseconds.
 	virtual ReadableString loadFromClipboard(double timeoutInSeconds = 0.5);
 	// Save text to the clipboard.
-	virtual void saveToClipboard(const ReadableString &text);
+	virtual void saveToClipboard(const ReadableString &text, double timeoutInSeconds = 0.5);
 public:
 	// Each callback declaration has a public variable and a public getter and setter
 	DECLARE_CALLBACK(closeEvent, emptyCallback);

--- a/Source/DFPSR/gui/BackendWindow.h
+++ b/Source/DFPSR/gui/BackendWindow.h
@@ -86,6 +86,15 @@ public:
 	virtual bool setCursorVisibility(bool visible) { return false; } // Returns true on success.
 	virtual void setCursorPosition(int x, int y) {} // Does nothing unless implemented.
 public:
+	// Clipboard interface
+	//   If none is replaced, both default implementations will use an internal variable.
+	//   If both are implemented, the system's clipboard should be accessed.
+	//   Partial implementations with only loadFromClipboard or saveToClipboard are not allowed.
+	// Load from the clipboard, waiting at most timeoutInMilliseconds milliseconds.
+	virtual ReadableString loadFromClipboard(int64_t timeoutInMilliseconds = 500);
+	// Save text to the clipboard.
+	virtual void saveToClipboard(const ReadableString &text);
+public:
 	// Each callback declaration has a public variable and a public getter and setter
 	DECLARE_CALLBACK(closeEvent, emptyCallback);
 	DECLARE_CALLBACK(resizeEvent, sizeCallback);

--- a/Source/DFPSR/gui/BackendWindow.h
+++ b/Source/DFPSR/gui/BackendWindow.h
@@ -91,7 +91,7 @@ public:
 	//   If both are implemented, the system's clipboard should be accessed.
 	//   Partial implementations with only loadFromClipboard or saveToClipboard are not allowed.
 	// Load from the clipboard, waiting at most timeoutInMilliseconds milliseconds.
-	virtual ReadableString loadFromClipboard(int64_t timeoutInMilliseconds = 500);
+	virtual ReadableString loadFromClipboard(double timeoutInSeconds = 0.5);
 	// Save text to the clipboard.
 	virtual void saveToClipboard(const ReadableString &text);
 public:

--- a/Source/DFPSR/gui/DsrWindow.cpp
+++ b/Source/DFPSR/gui/DsrWindow.cpp
@@ -268,6 +268,7 @@ String DsrWindow::getTitle() {
 }
 
 void DsrWindow::setTitle(const String &newTitle) {
+	return this->backend->setTitle(newTitle);
 }
 
 void DsrWindow::applyTheme(VisualTheme theme) {

--- a/Source/DFPSR/gui/DsrWindow.h
+++ b/Source/DFPSR/gui/DsrWindow.h
@@ -41,6 +41,8 @@ void gui_initialize();
 
 class DsrWindow {
 public:
+	// TODO: Should there be a separate interface context object to reduce the number of variables placed in each component?
+	//       If they all store a handle to the backend window, they could instead have a generic interface object storing pointers to the window, root, active components, et cetera...
 	// Window backend, which the API is allowed to call directly to bypass DsrWindow for trivial operations.
 	std::shared_ptr<BackendWindow> backend;
 private:

--- a/Source/DFPSR/gui/InputEvent.cpp
+++ b/Source/DFPSR/gui/InputEvent.cpp
@@ -64,18 +64,12 @@ inline String dsr::getName(DsrKey v) {
 		return U"Return";
 	} else if (v == DsrKey_BackSpace) {
 		return U"BackSpace";
-	} else if (v == DsrKey_LeftShift) {
-		return U"LeftShift";
-	} else if (v == DsrKey_RightShift) {
-		return U"RightShift";
-	} else if (v == DsrKey_LeftControl) {
-		return U"LeftControl";
-	} else if (v == DsrKey_RightControl) {
-		return U"RightControl";
-	} else if (v == DsrKey_LeftAlt) {
-		return U"LeftAlt";
-	} else if (v == DsrKey_RightAlt) {
-		return U"RightAlt";
+	} else if (v == DsrKey_Shift) {
+		return U"Shift";
+	} else if (v == DsrKey_Control) {
+		return U"Control";
+	} else if (v == DsrKey_Alt) {
+		return U"Alt";
 	} else if (v == DsrKey_Delete) {
 		return U"Delete";
 	} else if (v == DsrKey_LeftArrow) {

--- a/Source/DFPSR/gui/InputEvent.h
+++ b/Source/DFPSR/gui/InputEvent.h
@@ -42,10 +42,13 @@ enum class KeyboardEventType { KeyDown, KeyUp, KeyType };
 //   * DsrKey_0 to DsrKey_9 are guaranteed to be in an increasing serial order (so that "key - DsrKey_0" is the key's number)
 //   * DsrKey_F1 to DsrKey_F12 are guaranteed to be in an increasing serial order (so that "key - (DsrKey_F1 - 1)" is the key's number)
 //   * DsrKey_A to DsrKey_Z are guaranteed to be in an increasing serial order
+// Characters are case insensitive, because DsrKey refers to the physical key.
+//   Use the decoded Unicode value in DsrChar if you want to distinguish between upper and lower case or use special characters.
+// Control, shift and alt combines left and right sides, because sometimes the system does not say if the key is left or right.
 enum DsrKey {
 	DsrKey_LeftArrow, DsrKey_RightArrow, DsrKey_UpArrow, DsrKey_DownArrow, DsrKey_PageUp, DsrKey_PageDown,
-	DsrKey_LeftControl, DsrKey_RightControl, DsrKey_LeftShift, DsrKey_RightShift, DsrKey_LeftAlt, DsrKey_RightAlt,
-	DsrKey_Escape, DsrKey_Pause, DsrKey_Space, DsrKey_Tab, DsrKey_Return, DsrKey_BackSpace, DsrKey_Delete, DsrKey_Insert, DsrKey_Home, DsrKey_End,
+	DsrKey_Control, DsrKey_Shift, DsrKey_Alt, DsrKey_Escape, DsrKey_Pause, DsrKey_Space, DsrKey_Tab,
+	DsrKey_Return, DsrKey_BackSpace, DsrKey_Delete, DsrKey_Insert, DsrKey_Home, DsrKey_End,
 	DsrKey_0, DsrKey_1, DsrKey_2, DsrKey_3, DsrKey_4, DsrKey_5, DsrKey_6, DsrKey_7, DsrKey_8, DsrKey_9,
 	DsrKey_F1, DsrKey_F2, DsrKey_F3, DsrKey_F4, DsrKey_F5, DsrKey_F6, DsrKey_F7, DsrKey_F8, DsrKey_F9, DsrKey_F10, DsrKey_F11, DsrKey_F12,
 	DsrKey_A, DsrKey_B, DsrKey_C, DsrKey_D, DsrKey_E, DsrKey_F, DsrKey_G, DsrKey_H, DsrKey_I, DsrKey_J, DsrKey_K, DsrKey_L, DsrKey_M,

--- a/Source/DFPSR/gui/VisualComponent.cpp
+++ b/Source/DFPSR/gui/VisualComponent.cpp
@@ -262,6 +262,7 @@ void VisualComponent::addChildComponent(std::shared_ptr<VisualComponent> child) 
 		this->children.push(child);
 		this->childChanged = true;
 		child->parent = this;
+		child->window = this->window;
 	}
 }
 
@@ -289,6 +290,13 @@ std::shared_ptr<Persistent> VisualComponent::getChild(int index) const {
 	}
 }
 
+static void detachFromWindow(std::shared_ptr<VisualComponent> component) {
+	component->window = std::shared_ptr<BackendWindow>();
+	for (int c = 0; c < component->children.length(); c++) {
+		detachFromWindow(component->children[c]);
+	}
+}
+
 void VisualComponent::detachFromParent() {
 	// Check if there's a parent component
 	VisualComponent *parent = this->parent;
@@ -298,6 +306,8 @@ void VisualComponent::detachFromParent() {
 		for (int i = 0; i < parent->getChildCount(); i++) {
 			std::shared_ptr<VisualComponent> current = parent->children[i];
 			if (current.get() == this) {
+				// Disconnect child from backend window.
+				detachFromWindow(parent->children[i]);
 				// Disconnect parent from child.
 				current->parent = nullptr;
 				// Disconnect child from parent.
@@ -632,7 +642,7 @@ void VisualComponent::applyTheme(VisualTheme theme) {
 	this->theme = theme;
 	this->changedTheme(theme);
 	for (int i = 0; i < this->getChildCount(); i++) {
-		this->children[i] -> applyTheme(theme);
+		this->children[i]->applyTheme(theme);
 	}
 }
 

--- a/Source/DFPSR/gui/VisualComponent.h
+++ b/Source/DFPSR/gui/VisualComponent.h
@@ -25,7 +25,7 @@
 #define DFPSR_GUI_VISUALCOMPONENT
 
 #include "../persistent/includePersistent.h"
-#include "BackendWindow.h" // TODO: Separate event types from the window module
+#include "BackendWindow.h"
 #include "FlexRegion.h"
 #include "InputEvent.h"
 #include "VisualTheme.h"
@@ -58,6 +58,8 @@ static const ComponentState componentState_indirect = 0b101010101010101010101010
 class VisualComponent : public Persistent {
 PERSISTENT_DECLARATION(VisualComponent)
 public: // Relations
+	// Handle to the backend window.
+	std::shared_ptr<BackendWindow> window;
 	// Parent component
 	VisualComponent *parent = nullptr;
 	IRect givenSpace; // Remembering the local region that was reserved inside of the parent component.

--- a/Source/DFPSR/gui/components/TextBox.cpp
+++ b/Source/DFPSR/gui/components/TextBox.cpp
@@ -293,15 +293,6 @@ void TextBox::receiveMouseEvent(const MouseEvent& event) {
 	}
 }
 
-// TODO: Move stub implementation to an API and allow system wrappers to override it with a real implementation copying and pasting across different applications.
-String pasteBinStub;
-void saveToClipBoard(const ReadableString &text) {
-	pasteBinStub = text;
-}
-ReadableString readFromClipBoard() {
-	return pasteBinStub;
-}
-
 ReadableString TextBox::getSelectedText() {
 	int64_t selectionLeft = std::min(this->selectionStart, this->beamLocation);
 	int64_t selectionRight = std::max(this->selectionStart, this->beamLocation);
@@ -428,14 +419,26 @@ void TextBox::receiveKeyboardEvent(const KeyboardEvent& event) {
 				this->placeBeamAtCharacter(getLineEnd(this->text.value, this->beamLocation), removeSelection);
 			} else if (event.dsrKey == DsrKey_X) {
 				// Cut selection using Ctrl + X
-				saveToClipBoard(this->getSelectedText());
-				this->replaceSelection(U"");
+				if (this->window.get()) {
+					this->window->saveToClipboard(this->getSelectedText());
+					this->replaceSelection(U"");
+				} else {
+					sendWarning(U"No window handle found in TextBox when trying to cut text!");
+				}
 			} else if (event.dsrKey == DsrKey_C) {
 				// Copy selection using Ctrl + C
-				saveToClipBoard(this->getSelectedText());
+				if (this->window.get()) {
+					this->window->saveToClipboard(this->getSelectedText());
+				} else {
+					sendWarning(U"No window handle found in TextBox when trying to copy text!");
+				}
 			} else if (event.dsrKey == DsrKey_V) {
 				// Paste selection using Ctrl + V
-				this->replaceSelection(readFromClipBoard());
+				if (this->window.get()) {
+					this->replaceSelection(this->window->loadFromClipboard());
+				} else {
+					sendWarning(U"No window handle found in TextBox when trying to paste text!");
+				}
 			} else if (event.dsrKey == DsrKey_A) {
 				// Select all using Ctrl + A
 				this->selectionStart = 0;

--- a/Source/DFPSR/gui/components/TextBox.cpp
+++ b/Source/DFPSR/gui/components/TextBox.cpp
@@ -354,12 +354,8 @@ void TextBox::moveBeamVertically(int64_t rowIndexOffset, bool removeSelection) {
 	limitScrolling(true);
 }
 
-static const uint32_t combinationKey_leftShift = 1 << 0;
-static const uint32_t combinationKey_rightShift = 1 << 1;
-static const uint32_t combinationKey_shift = combinationKey_leftShift | combinationKey_rightShift;
-static const uint32_t combinationKey_leftControl = 1 << 2;
-static const uint32_t combinationKey_rightControl = 1 << 3;
-static const uint32_t combinationKey_control = combinationKey_leftControl | combinationKey_rightControl;
+static const uint32_t combinationKey_shift = 1 << 0;
+static const uint32_t combinationKey_control = 1 << 1;
 
 static int64_t getLineStart(const ReadableString &text, int64_t searchStart) {
 	for (int64_t i = searchStart - 1; i >= 0; i--) {
@@ -381,25 +377,19 @@ static int64_t getLineEnd(const ReadableString &text, int64_t searchStart) {
 
 void TextBox::receiveKeyboardEvent(const KeyboardEvent& event) {
 	// Insert and scroll-lock is not supported.
+	// To prevent getting stuck from missing a key event, one can reset by pressing and releasing again.
+	//   So if you press down both control keys and release one of them, it counts both as released.
 	if (event.keyboardEventType == KeyboardEventType::KeyDown) {
-		if (event.dsrKey == DsrKey_LeftShift) {
-			this->combinationKeys |= combinationKey_leftShift;
-		} else if (event.dsrKey == DsrKey_RightShift) {
-			this->combinationKeys |= combinationKey_rightShift;
-		} else if (event.dsrKey == DsrKey_LeftControl) {
-			this->combinationKeys |= combinationKey_leftControl;
-		} else if (event.dsrKey == DsrKey_RightControl) {
-			this->combinationKeys |= combinationKey_rightControl;
+		if (event.dsrKey == DsrKey_Shift) {
+			this->combinationKeys |= combinationKey_shift; // Enable shift
+		} else if (event.dsrKey == DsrKey_Control) {
+			this->combinationKeys |= combinationKey_control; // Enable control
 		}
 	} else if (event.keyboardEventType == KeyboardEventType::KeyUp) {
-		if (event.dsrKey == DsrKey_LeftShift) {
-			this->combinationKeys &= ~combinationKey_leftShift;
-		} else if (event.dsrKey == DsrKey_RightShift) {
-			this->combinationKeys &= ~combinationKey_rightShift;
-		} else if (event.dsrKey == DsrKey_LeftControl) {
-			this->combinationKeys &= ~combinationKey_leftControl;
-		} else if (event.dsrKey == DsrKey_RightControl) {
-			this->combinationKeys &= ~combinationKey_rightControl;
+		if (event.dsrKey == DsrKey_Shift) {
+			this->combinationKeys &= ~combinationKey_shift; // Disable shift
+		} else if (event.dsrKey == DsrKey_Control) {
+			this->combinationKeys &= ~combinationKey_control; // Disable control
 		}
 	} else if (event.keyboardEventType == KeyboardEventType::KeyType) {
 		int64_t textLength = string_length(this->text.value);

--- a/Source/windowManagers/Win32Window.cpp
+++ b/Source/windowManagers/Win32Window.cpp
@@ -317,21 +317,12 @@ static dsr::DsrKey getDsrKey(WPARAM keyCode) {
 		result = dsr::DsrKey_Return;
 	} else if (keyCode == VK_BACK) {
 		result = dsr::DsrKey_BackSpace;
-	} else if (keyCode == VK_LSHIFT || keyCode == VK_SHIFT) {
-		// If the keyboard does not tell if the shift is left or right, treat it like a left shift.
-		result = dsr::DsrKey_LeftShift;
-	} else if (keyCode == VK_RSHIFT) {
-		result = dsr::DsrKey_RightShift;
-	} else if (keyCode == VK_LCONTROL || keyCode == VK_CONTROL) {
-		// If the keyboard does not tell if control is left or right, treat it like left control.
-		result = dsr::DsrKey_LeftControl;
-	} else if (keyCode == VK_RCONTROL) {
-		result = dsr::DsrKey_RightControl;
-	} else if (keyCode == VK_LMENU || keyCode == VK_MENU) {
-		// If the keyboard does not tell if alt is left or right, treat it like left alt.
-		result = dsr::DsrKey_LeftAlt;
-	} else if (keyCode == VK_RMENU) {
-		result = dsr::DsrKey_RightAlt;
+	} else if (keyCode == VK_LSHIFT || keyCode == VK_SHIFT || keyCode == VK_RSHIFT) {
+		result = dsr::DsrKey_Shift;
+	} else if (keyCode == VK_LCONTROL || keyCode == VK_CONTROL || keyCode == VK_RCONTROL) {
+		result = dsr::DsrKey_Control;
+	} else if (keyCode == VK_LMENU || keyCode == VK_MENU || keyCode == VK_RMENU) {
+		result = dsr::DsrKey_Alt;
 	} else if (keyCode == VK_DELETE) {
 		result = dsr::DsrKey_Delete;
 	} else if (keyCode == VK_LEFT) {

--- a/Source/windowManagers/Win32Window.cpp
+++ b/Source/windowManagers/Win32Window.cpp
@@ -569,8 +569,14 @@ void Win32Window::resizeCanvas(int width, int height) {
 	// Create a new canvas
 	//   Even thou Windows is using RGBA pack order for the window, the bitmap format used for drawing is using BGRA order
 	for (int bufferIndex = 0; bufferIndex < bufferCount; bufferIndex++) {
+		dsr::AlignedImageRgbaU8 previousCanvas = this->canvas[bufferIndex];
 		this->canvas[bufferIndex] = dsr::image_create_RgbaU8_native(width, height, dsr::PackOrderIndex::BGRA);
+		if (image_exists(previousCanvas)) {
+			// Until the application's main loop has redrawn, fill the new canvas with a copy of the old one with black borders.
+			dsr::draw_copy(this->canvas[bufferIndex], previousCanvas);
+		}
 	}
+	this->firstFrame = true;
 }
 Win32Window::~Win32Window() {
 	#ifndef DISABLE_MULTI_THREADING

--- a/Source/windowManagers/Win32Window.cpp
+++ b/Source/windowManagers/Win32Window.cpp
@@ -317,15 +317,18 @@ static dsr::DsrKey getDsrKey(WPARAM keyCode) {
 		result = dsr::DsrKey_Return;
 	} else if (keyCode == VK_BACK) {
 		result = dsr::DsrKey_BackSpace;
-	} else if (keyCode == VK_LSHIFT) {
+	} else if (keyCode == VK_LSHIFT || keyCode == VK_SHIFT) {
+		// If the keyboard does not tell if the shift is left or right, treat it like a left shift.
 		result = dsr::DsrKey_LeftShift;
 	} else if (keyCode == VK_RSHIFT) {
 		result = dsr::DsrKey_RightShift;
-	} else if (keyCode == VK_LCONTROL) {
+	} else if (keyCode == VK_LCONTROL || keyCode == VK_CONTROL) {
+		// If the keyboard does not tell if control is left or right, treat it like left control.
 		result = dsr::DsrKey_LeftControl;
 	} else if (keyCode == VK_RCONTROL) {
 		result = dsr::DsrKey_RightControl;
-	} else if (keyCode == VK_LMENU) {
+	} else if (keyCode == VK_LMENU || keyCode == VK_MENU) {
+		// If the keyboard does not tell if alt is left or right, treat it like left alt.
 		result = dsr::DsrKey_LeftAlt;
 	} else if (keyCode == VK_RMENU) {
 		result = dsr::DsrKey_RightAlt;

--- a/Source/windowManagers/X11Window.cpp
+++ b/Source/windowManagers/X11Window.cpp
@@ -466,18 +466,12 @@ static dsr::DsrKey getDsrKey(KeySym keyCode) {
 		result = dsr::DsrKey_Return;
 	} else if (keyCode == XK_BackSpace) {
 		result = dsr::DsrKey_BackSpace;
-	} else if (keyCode == XK_Shift_L) {
-		result = dsr::DsrKey_LeftShift;
-	} else if (keyCode == XK_Shift_R) {
-		result = dsr::DsrKey_RightShift;
-	} else if (keyCode == XK_Control_L) {
-		result = dsr::DsrKey_LeftControl;
-	} else if (keyCode == XK_Control_R) {
-		result = dsr::DsrKey_RightControl;
-	} else if (keyCode == XK_Alt_L) {
-		result = dsr::DsrKey_LeftAlt;
-	} else if (keyCode == XK_Alt_R) {
-		result = dsr::DsrKey_RightAlt;
+	} else if (keyCode == XK_Shift_L || keyCode == XK_Shift_R) {
+		result = dsr::DsrKey_Shift;
+	} else if (keyCode == XK_Control_L || keyCode == XK_Control_R) {
+		result = dsr::DsrKey_Control;
+	} else if (keyCode == XK_Alt_L || keyCode == XK_Alt_R) {
+		result = dsr::DsrKey_Alt;
 	} else if (keyCode == XK_Delete) {
 		result = dsr::DsrKey_Delete;
 	} else if (keyCode == XK_Left) {

--- a/Source/windowManagers/X11Window.cpp
+++ b/Source/windowManagers/X11Window.cpp
@@ -108,7 +108,7 @@ public:
 	void initializeClipboard();
 	void terminateClipboard();		
 	dsr::ReadableString loadFromClipboard(double timeoutInSeconds);
-	void saveToClipboard(const dsr::ReadableString &text);
+	void saveToClipboard(const dsr::ReadableString &text, double timeoutInSeconds);
 };
 
 void X11Window::initializeClipboard() {
@@ -141,7 +141,7 @@ void X11Window::listContentInClipboard() {
 	XSetSelectionOwner(this->display, this->clipboardAtom, this->window, CurrentTime);
 }
 
-void X11Window::saveToClipboard(const dsr::ReadableString &text) {
+void X11Window::saveToClipboard(const dsr::ReadableString &text, double timeoutInSeconds) {
 	this->textToClipboard = text;
 	this->listContentInClipboard();
 }


### PR DESCRIPTION
Tested a bit and seems to work a lot better than not having it implemented at all. More handling of failures and legacy text encodings can be added in later commits to keep pull requests small.

This PR also merges left and right ctrl, shift and alt keycodes, because some keyboards on MS-Windows don't indicate left or right side.