### PR TITLE
Minor fixes

### DIFF
--- a/Source/DFPSR/api/imageAPI.h
+++ b/Source/DFPSR/api/imageAPI.h
@@ -233,10 +233,6 @@ namespace dsr {
 	uint8_t image_maxDifference(const ImageRgbaU8& imageA, const ImageRgbaU8& imageB);
 
 // Sub-images are viewports to another image's data
-// TODO: Aligned sub-images that only takes vertial sections using whole rows
-// TODO: Aligned sub-images that terminates with an error if the input rectangle isn't aligned
-//       Start must be 16-byte aligned, end must be same as the parent or also 16-byte aligned
-// TODO: Make an optional warning for not returning the desired dimensions when out of bound
 	// Get a sub-image sharing buffer and side-effects with the parent image
 	// Returns the overlapping region if out of bound
 	// Returns a null image if there are no overlapping pixels to return

--- a/Source/DFPSR/api/stringAPI.cpp
+++ b/Source/DFPSR/api/stringAPI.cpp
@@ -975,7 +975,7 @@ void dsr::string_unassignMessageHandler() {
 	globalMessageAction = defaultMessageAction;
 }
 
-void dsr::string_split_callback(std::function<void(ReadableString)> action, const ReadableString& source, DsrChar separator, bool removeWhiteSpace) {
+void dsr::string_split_callback(std::function<void(ReadableString separatedText)> action, const ReadableString& source, DsrChar separator, bool removeWhiteSpace) {
 	int64_t sectionStart = 0;
 	for (int64_t i = 0; i < source.length; i++) {
 		DsrChar c = source[i];

--- a/Source/DFPSR/api/stringAPI.cpp
+++ b/Source/DFPSR/api/stringAPI.cpp
@@ -1175,7 +1175,7 @@ bool dsr::string_isInteger(const ReadableString& source, bool allowWhiteSpace) {
 	if (allowWhiteSpace) {
 		PATTERN_STAR(WhiteSpace);
 	}
-	return true;
+	return readIndex == source.length;
 }
 
 // To avoid consuming the all digits on Digit* before reaching Digit+ when there is no decimal, whole integers are judged by string_isInteger
@@ -1201,7 +1201,7 @@ bool dsr::string_isDouble(const ReadableString& source, bool allowWhiteSpace) {
 		if (allowWhiteSpace) {
 			PATTERN_STAR(WhiteSpace);
 		}
-		return true;
+		return readIndex == source.length;
 	}
 }
 

--- a/Source/DFPSR/api/stringAPI.h
+++ b/Source/DFPSR/api/stringAPI.h
@@ -212,7 +212,7 @@ ReadableString string_after(const ReadableString& source, int64_t exclusiveStart
 // Split source into a list of strings.
 // Post-condition:
 //   Returns a list of strings from source by splitting along separator.
-//   If removeWhiteSpace is true then surrounding white-space will be removed, otherwise white-space is kept.
+//   If removeWhiteSpace is true then surrounding white-space will be removed, otherwise all white-space is kept.
 // The separating characters are excluded from the resulting strings.
 // The number of strings returned in the list will equal the number of separating characters plus one, so the result may contain empty strings.
 // Each string in the list clones content to its own dynamic buffer. Use string_split_callback if you don't need long term storage.
@@ -220,10 +220,10 @@ List<String> string_split(const ReadableString& source, DsrChar separator, bool 
 // Split a string without needing a list to store the result.
 // Use string_splitCount on the same source and separator if you need to know the element count in advance.
 // Side-effects:
-//   Calls action for each sub-string divided by separator in source.
-void string_split_callback(std::function<void(ReadableString)> action, const ReadableString& source, DsrChar separator, bool removeWhiteSpace = false);
+//   Calls action for each sub-string divided by separator in source given as the separatedText argument.
+void string_split_callback(std::function<void(ReadableString separatedText)> action, const ReadableString& source, DsrChar separator, bool removeWhiteSpace = false);
 // An alternative overload for having a very long lambda at the end.
-inline void string_split_callback(const ReadableString& source, DsrChar separator, bool removeWhiteSpace, std::function<void(ReadableString)> action) {
+inline void string_split_callback(const ReadableString& source, DsrChar separator, bool removeWhiteSpace, std::function<void(ReadableString separatedText)> action) {
 	string_split_callback(action, source, separator, removeWhiteSpace);
 }
 // Split source using separator, only to return the number of splits.

--- a/Source/DFPSR/base/SafePointer.cpp
+++ b/Source/DFPSR/base/SafePointer.cpp
@@ -1,6 +1,6 @@
 ﻿// zlib open source license
 //
-// Copyright (c) 2017 to 2019 David Forsgren Piuva
+// Copyright (c) 2017 to 2023 David Forsgren Piuva
 // 
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -26,13 +26,13 @@
 
 using namespace dsr;
 
-void dsr::assertNonNegativeSize(int size) {
+void dsr::assertNonNegativeSize(intptr_t size) {
 	if (size < 0) {
 		throwError(U"Negative size of SafePointer!\n");
 	}
 }
 
-void dsr::assertInsideSafePointer(const char* method, const char* name, const uint8_t* pointer, const uint8_t* data, const uint8_t* regionStart, const uint8_t* regionEnd, int claimedSize, int elementSize) {
+void dsr::assertInsideSafePointer(const char* method, const char* name, const uint8_t* pointer, const uint8_t* data, const uint8_t* regionStart, const uint8_t* regionEnd, intptr_t claimedSize, intptr_t elementSize) {
 	if (pointer < regionStart || pointer + claimedSize > regionEnd) {
 		String message;
 		if (data == nullptr) {
@@ -49,16 +49,16 @@ void dsr::assertInsideSafePointer(const char* method, const char* name, const ui
 		string_append(message, U"|  Requested pointer: ", (uintptr_t)pointer, U"\n");
 		string_append(message, U"|  Requested size: ", claimedSize, U" bytes\n");
 
-		int startOffset = (int)((intptr_t)pointer - (intptr_t)regionStart);
-		int baseOffset = (int)((intptr_t)pointer - (intptr_t)data);
+		intptr_t startOffset = (intptr_t)pointer - (intptr_t)regionStart;
+		intptr_t baseOffset = (intptr_t)pointer - (intptr_t)data;
 
 		// Index relative to allocation start
 		//   regionStart is the start of the accessible memory region
 		if (startOffset != baseOffset) {
 			string_append(message, U"|  Start offset: ", startOffset, U" bytes\n");
 			if (startOffset % elementSize == 0) {
-				int index = startOffset / elementSize;
-				int elementCount = ((int)((intptr_t)regionEnd - (intptr_t)regionStart)) / elementSize;
+				intptr_t index = startOffset / elementSize;
+				intptr_t elementCount = ((intptr_t)regionEnd - (intptr_t)regionStart) / elementSize;
 				string_append(message, U"|    Start index: ", index, U" [0..", (elementCount - 1), U"]\n");
 			}
 		}
@@ -67,8 +67,8 @@ void dsr::assertInsideSafePointer(const char* method, const char* name, const ui
 		//   data is the base of the allocation at index zero
 		string_append(message, U"|  Base offset: ", baseOffset, U" bytes\n");
 		if (baseOffset % elementSize == 0) {
-			int index = baseOffset / elementSize;
-			int elementCount = ((int)((intptr_t)regionEnd - (intptr_t)data)) / elementSize;
+			intptr_t index = baseOffset / elementSize;
+			intptr_t elementCount = ((intptr_t)regionEnd - (intptr_t)data) / elementSize;
 			string_append(message, U"|    Base index: ", index, U" [0..", (elementCount - 1), U"]\n");
 		}
 		string_append(message, U"\\_______________________________________________________________________\n\n");

--- a/Source/DFPSR/gui/InputEvent.h
+++ b/Source/DFPSR/gui/InputEvent.h
@@ -1,6 +1,6 @@
 ﻿// zlib open source license
 //
-// Copyright (c) 2018 to 2022 David Forsgren Piuva
+// Copyright (c) 2018 to 2023 David Forsgren Piuva
 // 
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -62,11 +62,11 @@ String& string_toStreamIndented(String& target, const DsrKey& source, const Read
 
 class KeyboardEvent : public InputEvent {
 public:
-	// What the user did to the key
+	// What the user did to the key.
 	KeyboardEventType keyboardEventType;
-	// The raw unicode value without any encoding
+	// The raw unicode value without any encoding.
 	DsrChar character;
-	// Minimal set of keys for portability
+	// Minimal set of keys for portability.
 	DsrKey dsrKey;
 	KeyboardEvent(KeyboardEventType keyboardEventType, DsrChar character, DsrKey dsrKey)
 	 : keyboardEventType(keyboardEventType), character(character), dsrKey(dsrKey) {}
@@ -112,26 +112,27 @@ public:
 	: windowEventType(windowEventType), width(width), height(height) {}
 };
 
-// A macro for declaring a virtual callback from the base method
-//   Use the getter for registering methods so that they can be forwarded to a wrapper without inheritance
-//   Use the actual variable beginning with `callback_` when calling the method from inside
+// A macro for declaring a virtual callback from the base method.
+//   Use the getter for registering methods so that they can be forwarded to a wrapper without inheritance.
+//   Use the actual variable beginning with `callback_` when calling the method from inside.
 #define DECLARE_CALLBACK(NAME, LAMBDA) \
 	decltype(LAMBDA) callback_##NAME = LAMBDA; \
 	decltype(LAMBDA)& NAME() { return callback_##NAME; }
 
-// The callback templates and types
-static std::function<void()> emptyCallback = []() {};
-using EmptyCallback = decltype(emptyCallback) ;
-static std::function<void(int)> indexCallback = [](int64_t index) {};
-using IndexCallback = decltype(indexCallback);
-static std::function<void(int, int)> sizeCallback = [](int width, int height) {};
-using SizeCallback = decltype(sizeCallback);
-static std::function<void(const KeyboardEvent&)> keyboardCallback = [](const KeyboardEvent& event) {};
-using KeyboardCallback = decltype(keyboardCallback);
-static std::function<void(const MouseEvent&)> mouseCallback = [](const MouseEvent& event) {};
-using MouseCallback = decltype(mouseCallback);
+// The callback types.
+using EmptyCallback = std::function<void()>;
+using IndexCallback = std::function<void(int index)>;
+using SizeCallback = std::function<void(int width, int height)>;
+using KeyboardCallback = std::function<void(const KeyboardEvent& event)>;
+using MouseCallback = std::function<void(const MouseEvent& event)>;
+
+// The default functions to call until a callback has been selected.
+static EmptyCallback emptyCallback = []() {};
+static IndexCallback indexCallback = [](int64_t index) {};
+static SizeCallback sizeCallback = [](int width, int height) {};
+static KeyboardCallback keyboardCallback = [](const KeyboardEvent& event) {};
+static MouseCallback mouseCallback = [](const MouseEvent& event) {};
 
 }
 
 #endif
-

--- a/Source/DFPSR/gui/components/TextBox.cpp
+++ b/Source/DFPSR/gui/components/TextBox.cpp
@@ -443,14 +443,28 @@ void TextBox::receiveKeyboardEvent(const KeyboardEvent& event) {
 			if (selected && (event.dsrKey == DsrKey_BackSpace || event.dsrKey == DsrKey_Delete)) {
 				// Remove selection
 				this->replaceSelection(U"");
-			} else if (event.dsrKey == DsrKey_BackSpace && canGoLeft) {
-				// Erase left of beam
-				this->beamLocation--;
-				this->replaceSelection(U"");
-			} else if (event.dsrKey == DsrKey_Delete && canGoRight) {
-				// Erase right of beam
-				this->beamLocation++;
-				this->replaceSelection(U"");
+			} else if (event.dsrKey == DsrKey_BackSpace) {
+				if (this->selectionStart == this->beamLocation) {
+					if (this->beamLocation > 0) {
+						// Erase left of beam
+						this->beamLocation--;
+						this->replaceSelection(U"");
+					}
+				} else {
+					// Erase selection
+					this->replaceSelection(U"");
+				}
+			} else if (event.dsrKey == DsrKey_Delete) {
+				if (this->selectionStart == this->beamLocation) {
+					if (this->beamLocation < textLength) {
+						// Erase right of beam
+						this->beamLocation++;
+						this->replaceSelection(U"");
+					}
+				} else {
+					// Erase selection
+					this->replaceSelection(U"");
+				}
 			} else if (event.dsrKey == DsrKey_Home) {
 				// Move to the line start using Home
 				this->placeBeamAtCharacter(getLineStart(this->text.value, this->beamLocation), removeSelection);

--- a/Source/test/tests/SimdTest.cpp
+++ b/Source/test/tests/SimdTest.cpp
@@ -1,6 +1,6 @@
 ﻿
 #include "../testTools.h"
-#include "../../DFPSR/base/simdExtra.h"
+#include "../../DFPSR/base/simd.h"
 
 START_TEST(Simd)
 	printText("\nSIMD test is compiled using:\n");

--- a/Source/test/tests/StringTest.cpp
+++ b/Source/test/tests/StringTest.cpp
@@ -146,6 +146,15 @@ START_TEST(String)
 		ASSERT_EQUAL(dsr::string_isInteger(U" 123"), true);
 		ASSERT_EQUAL(dsr::string_isInteger(U"-123"), true);
 		ASSERT_EQUAL(dsr::string_isInteger(U""), false);
+		ASSERT_EQUAL(dsr::string_isInteger(U"85x"), false);
+		ASSERT_EQUAL(dsr::string_isInteger(U"F15"), false);
+		ASSERT_EQUAL(dsr::string_isInteger(U" 14"), true);
+		ASSERT_EQUAL(dsr::string_isInteger(U"8 "), true);
+		ASSERT_EQUAL(dsr::string_isInteger(U"		100"), true);
+		ASSERT_EQUAL(dsr::string_isInteger(U"100		"), true);
+		ASSERT_EQUAL(dsr::string_isInteger(U"10 10"), false);
+		ASSERT_EQUAL(dsr::string_isInteger(U"10		10"), false);
+		ASSERT_EQUAL(dsr::string_isInteger(U" 10  10 "), false);
 		ASSERT_EQUAL(dsr::string_isDouble(U"0"), true);
 		ASSERT_EQUAL(dsr::string_isDouble(U"-0"), true);
 		ASSERT_EQUAL(dsr::string_isDouble(U"1"), true);
@@ -166,6 +175,10 @@ START_TEST(String)
 		ASSERT_EQUAL(dsr::string_isDouble(U"0.54321"), true);
 		ASSERT_EQUAL(dsr::string_isDouble(U"-0.54321"), true);
 		ASSERT_EQUAL(dsr::string_isDouble(U""), false);
+		ASSERT_EQUAL(dsr::string_isDouble(U"0..0"), false);
+		ASSERT_EQUAL(dsr::string_isDouble(U"M0.0"), false);
+		ASSERT_EQUAL(dsr::string_isDouble(U"0.0x"), false);
+		ASSERT_EQUAL(dsr::string_isDouble(U"T0.0q"), false);
 	}
 	// Upper case
 	ASSERT_MATCH(dsr::string_upperCase(U"a"), U"A");


### PR DESCRIPTION
Found an annoying bug in textboxes where deteting nothing inserted the command as a character when the condition for deleting was not met and the deleting keys were mistaken for printable. Should probably fix the printable classification as well, but this fixes the textbox.

Regular expressions for checking if something is a number forgot to check that all input was consumed before accepting, allowing garbage data after numbers.

Extended ranges for SafePointer, by using more intptr_t types.

Named arguments in some lambda functions.