### PR TITLE
Input tests

### DIFF
--- a/Source/DFPSR/gui/InputEvent.cpp
+++ b/Source/DFPSR/gui/InputEvent.cpp
@@ -25,7 +25,7 @@
 
 using namespace dsr;
 
-inline String dsr::getName(DsrKey v) {
+String dsr::getName(DsrKey v) {
 	if (v == DsrKey_Unhandled) {
 		return U"Other";
 	} else if (v == DsrKey_Escape) {
@@ -169,5 +169,108 @@ inline String dsr::getName(DsrKey v) {
 
 String& dsr::string_toStreamIndented(String& target, const DsrKey& source, const ReadableString& indentation) {
 	string_append(target, indentation, getName(source));
+	return target;
+}
+
+String dsr::getName(KeyboardEventType v) {
+	if (v == KeyboardEventType::KeyDown) {
+		return U"KeyDown"; // Pressing down a key on the keyboard.
+	} else if (v == KeyboardEventType::KeyUp) {
+		return U"KeyUp"; // Releasing a key on the keyboard.
+	} else if (v == KeyboardEventType::KeyType) {
+		return U"KeyType"; // The event that is sent repeatedly after holding down a character for a while.
+	} else {
+		return U"Invalid keyboard event type";
+	}
+}
+
+String& dsr::string_toStreamIndented(String& target, const KeyboardEventType& source, const ReadableString& indentation) {
+	string_append(target, indentation, getName(source));
+	return target;
+}
+
+String dsr::getName(MouseKeyEnum v) {
+	if (v == MouseKeyEnum::NoKey) {
+		return U"NoKey"; // For mouse move events.
+	} else if (v == MouseKeyEnum::Left) {
+		return U"Left"; // For mouse up and down events.
+	} else if (v == MouseKeyEnum::Right) {
+		return U"Right"; // For mouse up and down events.
+	} else if (v == MouseKeyEnum::Middle) {
+		return U"Middle"; // For mouse up and down events.
+	} else if (v == MouseKeyEnum::ScrollUp) {
+		return U"ScrollUp"; // For scroll events.
+	} else if (v == MouseKeyEnum::ScrollDown) {
+		return U"ScrollDown"; // For scroll events.
+	} else {
+		return U"Invalid mouse key enumeration";
+	}
+}
+
+String& dsr::string_toStreamIndented(String& target, const MouseKeyEnum& source, const ReadableString& indentation) {
+	string_append(target, indentation, getName(source));
+	return target;
+}
+
+String dsr::getName(MouseEventType v) {
+	if (v == MouseEventType::MouseDown) {
+		return U"MouseDown";
+	} else if (v == MouseEventType::MouseUp) {
+		return U"MouseUp";
+	} else if (v == MouseEventType::MouseMove) {
+		return U"MouseMove";
+	} else if (v == MouseEventType::Scroll) {
+		return U"Scroll";
+	} else {
+		return U"Invalid mouse event type";
+	}
+}
+
+String& dsr::string_toStreamIndented(String& target, const MouseEventType& source, const ReadableString& indentation) {
+	string_append(target, indentation, getName(source));
+	return target;
+}
+
+String dsr::getName(WindowEventType v) {
+	if (v == WindowEventType::Close) {
+		return U"Close";
+	} else if (v == WindowEventType::Redraw) {
+		return U"Redraw";
+	} else {
+		return U"Invalid window event type";
+	}
+}
+
+String& dsr::string_toStreamIndented(String& target, const WindowEventType& source, const ReadableString& indentation) {
+	string_append(target, indentation, getName(source));
+	return target;
+}
+
+String& dsr::string_toStreamIndented(String& target, const KeyboardEvent& source, const ReadableString& indentation) {
+	string_append(target, indentation, U"KeyboardEvent(");
+	string_append(target, U"keyboardEventType = ", source.keyboardEventType);
+	string_append(target, U", dsrKey = ", source.dsrKey);
+	string_append(target, U", character = ", source.character);
+	string_append(target, U")");
+	return target;
+}
+
+String& dsr::string_toStreamIndented(String& target, const MouseEvent& source, const ReadableString& indentation) {
+	string_append(target, indentation, U"MouseEvent(");
+	string_append(target, U"mouseEventType = ", source.mouseEventType);
+	// TODO: Assert that only the keys allowed by the mouse event type are given.
+	string_append(target, U", key = ", source.key);
+	string_append(target, U", position = ", source.position);
+	string_append(target, U")");
+	return target;
+}
+
+String& dsr::string_toStreamIndented(String& target, const WindowEvent& source, const ReadableString& indentation) {
+	string_append(target, indentation, U"WindowEvent(");
+	string_append(target, U"windowEventType = ", source.windowEventType);
+	// TODO: Assert that width and height are zero when not used by the event type.
+	string_append(target, U", width = ", source.width);
+	string_append(target, U", height = ", source.height);
+	string_append(target, U")");
 	return target;
 }

--- a/Source/DFPSR/gui/InputEvent.h
+++ b/Source/DFPSR/gui/InputEvent.h
@@ -57,9 +57,6 @@ enum DsrKey {
 	DsrKey_Unhandled
 };
 
-inline String getName(DsrKey v);
-String& string_toStreamIndented(String& target, const DsrKey& source, const ReadableString& indentation);
-
 class KeyboardEvent : public InputEvent {
 public:
 	// What the user did to the key.
@@ -132,6 +129,21 @@ static IndexCallback indexCallback = [](int64_t index) {};
 static SizeCallback sizeCallback = [](int width, int height) {};
 static KeyboardCallback keyboardCallback = [](const KeyboardEvent& event) {};
 static MouseCallback mouseCallback = [](const MouseEvent& event) {};
+
+// Conversion to text for easy debugging.
+String getName(DsrKey v);
+String getName(KeyboardEventType v);
+String getName(MouseKeyEnum v);
+String getName(MouseEventType v);
+String getName(WindowEventType v);
+String& string_toStreamIndented(String& target, const DsrKey& source, const ReadableString& indentation);
+String& string_toStreamIndented(String& target, const KeyboardEventType& source, const ReadableString& indentation);
+String& string_toStreamIndented(String& target, const MouseKeyEnum& source, const ReadableString& indentation);
+String& string_toStreamIndented(String& target, const MouseEventType& source, const ReadableString& indentation);
+String& string_toStreamIndented(String& target, const WindowEventType& source, const ReadableString& indentation);
+String& string_toStreamIndented(String& target, const KeyboardEvent& source, const ReadableString& indentation);
+String& string_toStreamIndented(String& target, const MouseEvent& source, const ReadableString& indentation);
+String& string_toStreamIndented(String& target, const WindowEvent& source, const ReadableString& indentation);
 
 }
 

--- a/Source/SDK/integrationTest/Description.txt
+++ b/Source/SDK/integrationTest/Description.txt
@@ -1,0 +1,1 @@
+﻿Integration test program to check if you have ported the framework correctly to a new operating system.

--- a/Source/SDK/integrationTest/IntegrationTest.DsrProj
+++ b/Source/SDK/integrationTest/IntegrationTest.DsrProj
@@ -1,0 +1,15 @@
+﻿CompilerFlag "-std=c++14"
+ReuseMemory
+Graphics
+#Sound
+Crawl "main.cpp"
+Import "../../DFPSR/DFPSR.DsrHead"
+
+# Linking statically to standard C/C++ libraries allow running the program without installing them.
+#   Recommended for making an installer for another application or programs that should not need an installer.
+# If you don't want static linking of standard C/C++ libraries, you have to comment out StaticRuntime
+#   and bundle the C/C++ runtime of the compiler with your program's installer.
+StaticRuntime
+
+# Uncomment to enable debug mode, which is slower
+#Debug

--- a/Source/SDK/integrationTest/Test.cpp
+++ b/Source/SDK/integrationTest/Test.cpp
@@ -25,12 +25,13 @@ void TestContext::passTask() {
 
 void TestContext::finishTest(Grade result) {
 	if (result == Grade::Passed) {
-		printText(U"Passed \"", tests[testIndex].name, U"\".");
+		printText(U"Passed \"", tests[testIndex].name, U"\"\n.");
 	} else if (result == Grade::Skipped) {
-		sendWarning(U"Skipped \"", tests[testIndex].name, U"\".");
+		sendWarning(U"Skipped \"", tests[testIndex].name, U"\"\n.");
 	} else if (result == Grade::Failed) {
-		sendWarning(U"Failed \"", tests[testIndex].name, U"\".");
+		sendWarning(U"Failed \"", tests[testIndex].name, U"\"\n.");
 	}
 	tests[testIndex].result = result;
 	testIndex++;
+	taskIndex = 0;
 }

--- a/Source/SDK/integrationTest/Test.cpp
+++ b/Source/SDK/integrationTest/Test.cpp
@@ -39,6 +39,6 @@ void TestContext::finishTest(Grade result) {
 void TestContext::drawAides(AlignedImageRgbaU8 &canvas) {
 	int width = image_getWidth(canvas);
 	int height = image_getHeight(canvas);
-	draw_rectangle(canvas, IRect(0, this->lastPosition.y - 1, width, 3), ColorRgbaI32(0, 0, 0, 255));
-	draw_rectangle(canvas, IRect(this->lastPosition.x - 1, 0, 3, height), ColorRgbaI32(0, 0, 0, 255));
+	draw_rectangle(canvas, IRect(0, this->lastPosition.y - 1, width, 3), ColorRgbaI32(180, 180, 180, 255));
+	draw_rectangle(canvas, IRect(this->lastPosition.x - 1, 0, 3, height), ColorRgbaI32(180, 180, 180, 255));
 }

--- a/Source/SDK/integrationTest/Test.cpp
+++ b/Source/SDK/integrationTest/Test.cpp
@@ -1,0 +1,36 @@
+
+#include "Test.h"
+
+using namespace dsr;
+
+String& string_toStreamIndented(String& target, const Grade& grade, const ReadableString& indentation) {
+	if (grade == Grade::Waiting) {
+		string_append(target, indentation, U"Waiting");
+	} else if (grade == Grade::Passed) {
+		string_append(target, indentation, U"Passed");
+	} else if (grade == Grade::Skipped) {
+		string_append(target, indentation, U"Skipped");
+	} else if (grade == Grade::Failed) {
+		string_append(target, indentation, U"Failed");
+	} else {
+		string_append(target, indentation, U"?");
+	}
+	return target;
+}
+
+// Call when completing a task but not a whole test.
+void TestContext::passTask() {
+	taskIndex++;
+}
+
+void TestContext::finishTest(Grade result) {
+	if (result == Grade::Passed) {
+		printText(U"Passed \"", tests[testIndex].name, U"\".");
+	} else if (result == Grade::Skipped) {
+		sendWarning(U"Skipped \"", tests[testIndex].name, U"\".");
+	} else if (result == Grade::Failed) {
+		sendWarning(U"Failed \"", tests[testIndex].name, U"\".");
+	}
+	tests[testIndex].result = result;
+	testIndex++;
+}

--- a/Source/SDK/integrationTest/Test.cpp
+++ b/Source/SDK/integrationTest/Test.cpp
@@ -35,3 +35,10 @@ void TestContext::finishTest(Grade result) {
 	testIndex++;
 	taskIndex = 0;
 }
+
+void TestContext::drawAides(AlignedImageRgbaU8 &canvas) {
+	int width = image_getWidth(canvas);
+	int height = image_getHeight(canvas);
+	draw_rectangle(canvas, IRect(0, this->lastPosition.y - 1, width, 3), ColorRgbaI32(0, 0, 0, 255));
+	draw_rectangle(canvas, IRect(this->lastPosition.x - 1, 0, 3, height), ColorRgbaI32(0, 0, 0, 255));
+}

--- a/Source/SDK/integrationTest/Test.h
+++ b/Source/SDK/integrationTest/Test.h
@@ -1,0 +1,58 @@
+
+#include "../../DFPSR/includeFramework.h"
+
+struct TestContext;
+
+using DrawContextCallback = std::function<void(dsr::AlignedImageRgbaU8 &canvas, TestContext &context)>;
+using MouseContextCallback = std::function<void(const dsr::MouseEvent &event, TestContext &context)>;
+using KeyboardContextCallback = std::function<void(const dsr::KeyboardEvent &event, TestContext &context)>;
+
+enum class Grade {
+	Waiting,
+	Passed,
+	Skipped,
+	Failed
+};
+
+struct Test {
+	dsr::String name;
+	DrawContextCallback drawEvent;
+	MouseContextCallback mouseCallback;
+	KeyboardContextCallback keyboardCallback;
+	bool activeDrawing;
+	Grade result = Grade::Waiting;
+	Test(const dsr::ReadableString& name, const DrawContextCallback &drawEvent, const MouseContextCallback &mouseCallback, const KeyboardContextCallback &keyboardCallback, bool activeDrawing)
+	: drawEvent(drawEvent), mouseCallback(mouseCallback), keyboardCallback(keyboardCallback), activeDrawing(activeDrawing) {}
+};
+
+struct TestContext {
+	dsr::List<Test> tests;
+
+	// Each test consists of one or more tasks to pass.
+	int testIndex = 0; // Each test index refers to a Test in tests to be completed.
+	int taskIndex = 0; // To avoid cluttering the summary with lots of small tests, tests are divided into smaller tasks.
+
+	// Call when completing a task but not a whole test.
+	void passTask() {
+		taskIndex++;
+	}
+
+	// Call when completing a test.
+	void finishTest(Grade result) {
+		if (result == Grade::Passed) {
+			printText(U"Passed \"", tests[testIndex].name, U"\".");
+		} else if (result == Grade::Skipped) {
+			printText(U"Skipped \"", tests[testIndex].name, U"\".");
+		} else if (result == Grade::Failed) {
+			printText(U"Failed \"", tests[testIndex].name, U"\".");
+		}
+		tests[testIndex].result = result;
+		testIndex++;
+	}
+
+	bool leftMouseDown = false;
+	bool middleMouseDown = false;
+	bool rightMouseDown = false;
+
+	TestContext() {}
+};

--- a/Source/SDK/integrationTest/Test.h
+++ b/Source/SDK/integrationTest/Test.h
@@ -40,9 +40,13 @@ struct TestContext {
 	// Call when completing a test.
 	void finishTest(Grade result);
 
+	void drawAides(dsr::AlignedImageRgbaU8 &canvas);
+
 	bool leftMouseDown = false;
 	bool middleMouseDown = false;
 	bool rightMouseDown = false;
+
+	dsr::IVector2D lastPosition;
 
 	TestContext() {}
 };

--- a/Source/SDK/integrationTest/Test.h
+++ b/Source/SDK/integrationTest/Test.h
@@ -14,6 +14,8 @@ enum class Grade {
 	Failed
 };
 
+dsr::String& string_toStreamIndented(dsr::String& target, const Grade& grade, const dsr::ReadableString& indentation);
+
 struct Test {
 	dsr::String name;
 	DrawContextCallback drawEvent;
@@ -22,7 +24,7 @@ struct Test {
 	bool activeDrawing;
 	Grade result = Grade::Waiting;
 	Test(const dsr::ReadableString& name, const DrawContextCallback &drawEvent, const MouseContextCallback &mouseCallback, const KeyboardContextCallback &keyboardCallback, bool activeDrawing)
-	: drawEvent(drawEvent), mouseCallback(mouseCallback), keyboardCallback(keyboardCallback), activeDrawing(activeDrawing) {}
+	: name(name), drawEvent(drawEvent), mouseCallback(mouseCallback), keyboardCallback(keyboardCallback), activeDrawing(activeDrawing) {}
 };
 
 struct TestContext {
@@ -33,22 +35,10 @@ struct TestContext {
 	int taskIndex = 0; // To avoid cluttering the summary with lots of small tests, tests are divided into smaller tasks.
 
 	// Call when completing a task but not a whole test.
-	void passTask() {
-		taskIndex++;
-	}
+	void passTask();
 
 	// Call when completing a test.
-	void finishTest(Grade result) {
-		if (result == Grade::Passed) {
-			printText(U"Passed \"", tests[testIndex].name, U"\".");
-		} else if (result == Grade::Skipped) {
-			printText(U"Skipped \"", tests[testIndex].name, U"\".");
-		} else if (result == Grade::Failed) {
-			printText(U"Failed \"", tests[testIndex].name, U"\".");
-		}
-		tests[testIndex].result = result;
-		testIndex++;
-	}
+	void finishTest(Grade result);
 
 	bool leftMouseDown = false;
 	bool middleMouseDown = false;

--- a/Source/SDK/integrationTest/build_linux.sh
+++ b/Source/SDK/integrationTest/build_linux.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Launch the build system with IntegrationTest.DsrProj and Linux selected as the platform.
+echo "Running build_linux.sh $@"
+chmod +x ../../tools/builder/buildProject.sh;
+../../tools/builder/buildProject.sh IntegrationTest.DsrProj Linux $@;

--- a/Source/SDK/integrationTest/build_windows.bat
+++ b/Source/SDK/integrationTest/build_windows.bat
@@ -1,0 +1,6 @@
+@echo off
+
+rem Launch the build system with IntegrationTest.DsrProj and Windows selected as the platform.
+
+echo "Running build_windows.bat %@%
+..\..\tools\builder\buildProject.bat IntegrationTest.DsrProj Windows %@%

--- a/Source/SDK/integrationTest/main.cpp
+++ b/Source/SDK/integrationTest/main.cpp
@@ -34,14 +34,8 @@ void dsrMain(List<String> args) {
 	window = window_create(U"Integration test", 800, 600);
 
 	// Create tests.
-	// TODO: Allow selecting which tests to add using settings and white which categories were skipped in the final summary.
-	//       Can have a screen where one gets to check types of tests and available device features.
-	//       Some might want to skip tests that require certain types of input.
-	//       One should have a mouse with vertical scroll wheel and three buttons to test it all. (The scroll wheel can often be clicked on as a middle mouse button)
-	//       The media layer currently does not support horizontal scrolling, because otherwise one would need a laptop with each operating system just to test it.
-	//       It is however cheap and easy to attach a three button mouse.
-	//       A stylus pen with only two buttons, no scroll and no relative input will only be able to perform some of the tests.
-	inputTests_populate(context.tests);
+	// TODO: Ask the user which kinds of inputs are available and use that information to select the correct tests.
+	inputTests_populate(context.tests, 3, true, true);
 
 	// Create finishing screen showing results.
 	context.tests.pushConstruct(
@@ -49,8 +43,12 @@ void dsrMain(List<String> args) {
 	,
 		[](AlignedImageRgbaU8 &canvas, TestContext &context) {
 			image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
-			font_printLine(canvas, font_getDefault(), U"Completed integration test.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
-			// TODO: Print a summary with named tests and their grades in a colored table.
+			font_printLine(canvas, font_getDefault(), U"Test summary:", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+			for (int t = 0; t < context.tests.length() - 1; t++) {
+				font_printLine(canvas, font_getDefault(), string_combine(context.tests[t].result, U" - ", context.tests[t].name), IVector2D(60, t * 20 + 60), ColorRgbaI32(0, 0, 0, 255));
+			}
+			// TODO: Allow scrolling through the results if it gets too much to fit inside the window.
+			// TODO: Also print this information to the terminal, in case that it is difficult to see.
 		}
 	,
 		[](const MouseEvent& event, TestContext &context) {}

--- a/Source/SDK/integrationTest/main.cpp
+++ b/Source/SDK/integrationTest/main.cpp
@@ -61,6 +61,9 @@ void dsrMain(List<String> args) {
 	// TODO: Move to a method taking window as the argument in Test.cpp.
 	window_setMouseEvent(window, [](const MouseEvent& event) {
 		if (event.mouseEventType == MouseEventType::MouseDown) {
+			if (context.lastPosition != event.position) {
+				sendWarning(U"A mouse (button) down event changed the cursor location! Unless the window moved while the mouse was standing still, something might be wrong. Check if mouse move events are missing, off or arriving too late.\n");
+			}
 			if (event.key == MouseKeyEnum::Left) {
 				context.leftMouseDown = true;
 			} else if (event.key == MouseKeyEnum::Middle) {
@@ -69,6 +72,9 @@ void dsrMain(List<String> args) {
 				context.rightMouseDown = true;
 			}
 		} else if (event.mouseEventType == MouseEventType::MouseUp) {
+			if (context.lastPosition != event.position) {
+				sendWarning(U"A mouse (button) up event changed the cursor location! Unless the window moved while the mouse was standing still, something might be wrong. Check if mouse move events are missing, off or arriving too late.\n");
+			}
 			if (event.key == MouseKeyEnum::Left) {
 				context.leftMouseDown = false;
 			} else if (event.key == MouseKeyEnum::Middle) {
@@ -77,6 +83,7 @@ void dsrMain(List<String> args) {
 				context.rightMouseDown = false;
 			}
 		}
+		context.lastPosition = event.position;
 		if (context.testIndex >= 0 && context.testIndex < context.tests.length()) {
 			context.tests[context.testIndex].mouseCallback(event, context);
 		}

--- a/Source/SDK/integrationTest/main.cpp
+++ b/Source/SDK/integrationTest/main.cpp
@@ -1,0 +1,123 @@
+﻿
+// An integration test application to quickly go through the most essential features to test in new implementations inheriting BackendWindow in the windowManagers folder.
+//   Instead of reading documentation with risk of missunderstanding something, this integration test should guide the developer through the stages and give hints on what is wrong and how to fix it.
+//   It should be somewhat difficult to pass the test by accident without having integrated the media layer correctly with the operating system.
+
+// Planned tests:
+// * Update the image one frame at a time while showing digits, then move on to the next digit after having pressed the correct key on the keyboard.
+//   By randomizing the order, one can see if the keys are mapped wrong or if the canvas upload is delayed to show old images.
+//   One can also show a frame counter for easy debugging.
+//   Might need to use a boolean flag to manually say when it is okay to update the canvas.
+//   Any repaint or resize events during the time may prove problematic, because the canvas should be possible to update once without getting duplicate requests.
+// * Before the real tests begin, have a mode where one can freely move the mouse and get ripple animations from pressing, scrolling and hovering.
+//   See the names of buttons being pressed, so that one can quickly try things out before starting the test.
+// * Press and hold a keyboard button for ten seconds without getting any up or down events in between.
+//   Features for repeated key presses have to be filtered out, so that up and down is only triggered by physical up and down events.
+// * Press all the keys on the keyboard and see them light up on a picture of a keyboard as you type.
+//   Create a reusable component for handling keyboard input, which can also be used to bind keys in a game.
+// * Ask if relative input (mouse/ball/trackpad) is available and skip tests if not available.
+//   Enter full screen and rotate a 3D camera in a cube map sky by moving the cursor to the center of the window.
+//   Is there any clean way to allocate temporary resources for 3D graphics without creating an error-prone mess of pointers and inheritance?
+
+#include "../../DFPSR/includeFramework.h"
+#include "tests/inputTest.h"
+
+using namespace dsr;
+
+Window window;
+bool running = true;
+TestContext context;
+
+DSR_MAIN_CALLER(dsrMain)
+void dsrMain(List<String> args) {
+	// Create a window
+	window = window_create(U"Integration test", 800, 600);
+
+	// Create tests.
+	// TODO: Allow selecting which tests to add using settings and white which categories were skipped in the final summary.
+	//       Can have a screen where one gets to check types of tests and available device features.
+	//       Some might want to skip tests that require certain types of input.
+	//       One should have a mouse with vertical scroll wheel and three buttons to test it all. (The scroll wheel can often be clicked on as a middle mouse button)
+	//       The media layer currently does not support horizontal scrolling, because otherwise one would need a laptop with each operating system just to test it.
+	//       It is however cheap and easy to attach a three button mouse.
+	//       A stylus pen with only two buttons, no scroll and no relative input will only be able to perform some of the tests.
+	inputTests_populate(context.tests);
+
+	// Create finishing screen showing results.
+	context.tests.pushConstruct(
+		U"Summary"
+	,
+		[](AlignedImageRgbaU8 &canvas, TestContext &context) {
+			image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
+			font_printLine(canvas, font_getDefault(), U"Completed integration test.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+			// TODO: Print a summary with named tests and their grades in a colored table.
+		}
+	,
+		[](const MouseEvent& event, TestContext &context) {}
+	,
+		[](const KeyboardEvent& event, TestContext &context) {}
+	,
+		false
+	);
+
+	// TODO: Move to a method taking window as the argument in Test.cpp.
+	window_setMouseEvent(window, [](const MouseEvent& event) {
+		if (event.mouseEventType == MouseEventType::MouseDown) {
+			if (event.key == MouseKeyEnum::Left) {
+				context.leftMouseDown = true;
+			} else if (event.key == MouseKeyEnum::Middle) {
+				context.middleMouseDown = true;
+			} else if (event.key == MouseKeyEnum::Right) {
+				context.rightMouseDown = true;
+			}
+		} else if (event.mouseEventType == MouseEventType::MouseUp) {
+			if (event.key == MouseKeyEnum::Left) {
+				context.leftMouseDown = false;
+			} else if (event.key == MouseKeyEnum::Middle) {
+				context.middleMouseDown = false;
+			} else if (event.key == MouseKeyEnum::Right) {
+				context.rightMouseDown = false;
+			}
+		}
+		if (context.testIndex >= 0 && context.testIndex < context.tests.length()) {
+			context.tests[context.testIndex].mouseCallback(event, context);
+		}
+	});
+	window_setKeyboardEvent(window, [](const KeyboardEvent& event) {
+		if (context.testIndex >= 0 && context.testIndex < context.tests.length()) {
+			if (event.keyboardEventType == KeyboardEventType::KeyDown && event.dsrKey == DsrKey::DsrKey_Escape) {
+				if (context.testIndex >= context.tests.length() - 1) {
+					running = false;
+				} else {
+					context.finishTest(Grade::Skipped);
+				}
+			} else {
+				context.tests[context.testIndex].keyboardCallback(event, context);
+			}
+		}
+	});
+
+	window_setCloseEvent(window, []() {
+		running = false;
+	});
+
+	// Execute
+	while(running) {
+		if (context.tests[context.testIndex].activeDrawing) {
+			window_executeEvents(window);
+		} else {
+			// Wait for actions
+			while (!window_executeEvents(window)) {
+				time_sleepSeconds(0.01);
+			}
+		}
+		// Get the current canvas from the swap chain.
+		AlignedImageRgbaU8 canvas = window_getCanvas(window);
+		// Draw things to the canvas.
+		if (context.testIndex >= 0 && context.testIndex < context.tests.length()) {
+			context.tests[context.testIndex].drawEvent(canvas, context);
+		}
+		// Show the canvas.
+		window_showCanvas(window);
+	}
+}

--- a/Source/SDK/integrationTest/tests/inputTest.cpp
+++ b/Source/SDK/integrationTest/tests/inputTest.cpp
@@ -3,37 +3,42 @@
 
 using namespace dsr;
 
+#define TASK_IS(INDEX) context.taskIndex == INDEX
+#define EVENT_TYPE_IS(TYPE) event.mouseEventType == MouseEventType::TYPE
+
 void inputTests_populate(List<Test> &target, int buttonCount, bool relative, bool verticalScroll) {
-	// TODO: Make notes about which tests were skipped and why.
 	if (buttonCount >= 1) {
 		target.pushConstruct(
 			U"Mouse drag test"
 		,
 			[](AlignedImageRgbaU8 &canvas, TestContext &context) {
 				image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
-				if (context.taskIndex == 0) {
+				if (TASK_IS(0)) {
 					font_printLine(canvas, font_getDefault(), U"Hover the cursor over the window.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
-				} else if (context.taskIndex == 1) {
+				} else if (TASK_IS(1)) {
 					font_printLine(canvas, font_getDefault(), U"Press down the left mouse key.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
-				} else if (context.taskIndex == 2) {
+				} else if (TASK_IS(2)) {
 					font_printLine(canvas, font_getDefault(), U"Drag the mouse over the window with the left key pressed down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
-				} else if (context.taskIndex == 3) {
+				} else if (TASK_IS(3)) {
 					font_printLine(canvas, font_getDefault(), U"Release the left key.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				}
+				// TODO: Draw expanding circles from lowering and raising buttons together with names of the keys used.
+				// TODO: Draw fading lines from move events.
+				// TODO: Make a reusable drawing system to be enabled or disabled as a reusable mouse visualization feature.
 			}
 		,
 			[](const MouseEvent& event, TestContext &context) {
-				if (context.taskIndex == 0 && event.mouseEventType == MouseEventType::MouseMove && !context.leftMouseDown && !context.middleMouseDown && !context.rightMouseDown) {
+				if (TASK_IS(0) && EVENT_TYPE_IS(MouseMove) && !context.leftMouseDown && !context.middleMouseDown && !context.rightMouseDown) {
 					context.passTask();
-				} else if (context.taskIndex == 1 && event.mouseEventType == MouseEventType::MouseDown) {
+				} else if (TASK_IS(1) && EVENT_TYPE_IS(MouseDown)) {
 					if (event.key == MouseKeyEnum::Left) {
 						context.passTask();
 					} else {
 						// TODO: Say which key was triggered instead and suggest skipping with escape if it can not be found.
 					}
-				} else if (context.taskIndex == 2 && event.mouseEventType == MouseEventType::MouseMove && context.leftMouseDown) {
+				} else if (TASK_IS(2) && EVENT_TYPE_IS(MouseMove) && context.leftMouseDown) {
 					context.passTask();
-				} else if (context.taskIndex == 3 && event.mouseEventType == MouseEventType::MouseUp) {
+				} else if (TASK_IS(3) && EVENT_TYPE_IS(MouseUp)) {
 					if (event.key == MouseKeyEnum::Left) {
 						context.finishTest(Grade::Passed);
 					} else {
@@ -47,6 +52,9 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 			false
 		);
 	} else {
-		sendWarning(U"Skipped the left mouse button test, because 0 mouse buttons were selected as available.");
+		sendWarning(U"Skipped the left mouse button test, because no mouse buttons were told to be available in the call to inputTests_populate.");
 	}
+	// TODO: Create tests for other mouse buttons by reusing code in functions.
+	// TODO: Create tests for keyboards, that display pressed physical keys on a QWERTY keyboard and unicode values of characters.
+	//       The actual printed values depend on language settings, so this might have to be checked manually.
 }

--- a/Source/SDK/integrationTest/tests/inputTest.cpp
+++ b/Source/SDK/integrationTest/tests/inputTest.cpp
@@ -7,6 +7,64 @@ using namespace dsr;
 #define EVENT_TYPE_IS(TYPE) event.mouseEventType == MouseEventType::TYPE
 
 void inputTests_populate(List<Test> &target, int buttonCount, bool relative, bool verticalScroll) {
+	if (buttonCount >= 3) {
+		target.pushConstruct(
+			U"Mouse button test"
+		,
+			[](AlignedImageRgbaU8 &canvas, TestContext &context) {
+				image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
+				if (TASK_IS(0)) {
+					font_printLine(canvas, font_getDefault(), U"Press down the left mouse button, .", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (TASK_IS(1)) {
+					font_printLine(canvas, font_getDefault(), U"Release the left mouse button.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (TASK_IS(2)) {
+					font_printLine(canvas, font_getDefault(), U"Press down the right mouse button.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (TASK_IS(3)) {
+					font_printLine(canvas, font_getDefault(), U"Release the right mouse button.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (TASK_IS(4)) {
+					font_printLine(canvas, font_getDefault(), U"Press down the middle mouse button.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (TASK_IS(5)) {
+					font_printLine(canvas, font_getDefault(), U"Release the middle mouse button.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				}
+				// TODO: Draw expanding circles from lowering and raising buttons together with names of the keys used.
+				// TODO: Draw fading lines from move events.
+				// TODO: Make a reusable drawing system to be enabled or disabled as a reusable mouse visualization feature.
+			}
+		,
+			[](const MouseEvent& event, TestContext &context) {
+				if (EVENT_TYPE_IS(MouseDown)) {
+					if (TASK_IS(0) && event.key == MouseKeyEnum::Left) {
+						context.passTask();
+					} else if (TASK_IS(2) && event.key == MouseKeyEnum::Right) {
+						context.passTask();
+					} else if (TASK_IS(4) && event.key == MouseKeyEnum::Middle) {
+						context.passTask();
+					} else {
+						sendWarning(U"Detected a different key!\n");
+					}
+				} else if (EVENT_TYPE_IS(MouseUp)) {
+					if (TASK_IS(1) && event.key == MouseKeyEnum::Left) {
+						context.passTask();
+					} else if (TASK_IS(3) && event.key == MouseKeyEnum::Right) {
+						context.passTask();
+					} else if (TASK_IS(5) && event.key == MouseKeyEnum::Middle) {
+						context.finishTest(Grade::Passed);
+					} else {
+						sendWarning(U"Detected a different key!\n");
+					}
+				}
+			}
+		,
+			[](const KeyboardEvent& event, TestContext &context) {
+				sendWarning(U"Detected a keyboard event with ", event.dsrKey, " instead of a mouse button!\n");
+			}
+		,
+			false
+		);
+	} else {
+		sendWarning(U"Skipped the left mouse button test due to settings.");
+	}
+
 	if (buttonCount >= 1) {
 		target.pushConstruct(
 			U"Mouse drag test"

--- a/Source/SDK/integrationTest/tests/inputTest.cpp
+++ b/Source/SDK/integrationTest/tests/inputTest.cpp
@@ -29,7 +29,6 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 				}
 				// TODO: Draw expanding circles from lowering and raising buttons together with names of the keys used.
 				// TODO: Draw fading lines from move events.
-				// TODO: Make a reusable drawing system to be enabled or disabled as a reusable mouse visualization feature.
 			}
 		,
 			[](const MouseEvent& event, TestContext &context) {
@@ -82,9 +81,6 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 				} else if (TASK_IS(3)) {
 					font_printLine(canvas, font_getDefault(), U"Release the left key.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				}
-				// TODO: Draw expanding circles from lowering and raising buttons together with names of the keys used.
-				// TODO: Draw fading lines from move events.
-				// TODO: Make a reusable drawing system to be enabled or disabled as a reusable mouse visualization feature.
 			}
 		,
 			[](const MouseEvent& event, TestContext &context) {
@@ -164,7 +160,36 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 	} else {
 		sendWarning(U"Skipped the vertical scroll test due to settings.\n");
 	}
-	// TODO: Create tests for other mouse buttons by reusing code in functions.
-	// TODO: Create tests for keyboards, that display pressed physical keys on a QWERTY keyboard and unicode values of characters.
-	//       The actual printed values depend on language settings, so this might have to be checked manually.
+	target.pushConstruct(
+		U"Keyboard test"
+	,
+		[](AlignedImageRgbaU8 &canvas, TestContext &context) {
+			image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
+			// TODO: Draw a keyboard showing which key is expected and which key was detected.
+			if (context.taskIndex < DsrKey::DsrKey_Unhandled) {
+				font_printLine(canvas, font_getDefault(), string_combine(U"Press down ", (DsrKey)context.taskIndex, " on your physical or virtual keyboard."), IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+			}
+		}
+	,
+		[](const MouseEvent& event, TestContext &context) {
+			sendWarning(U"Detected a mouse event with ", event.key, " instead of a keyboard event!\n");
+		}
+	,
+		[](const KeyboardEvent& event, TestContext &context) {
+			if (event.keyboardEventType == KeyboardEventType::KeyDown && event.dsrKey == context.taskIndex) {
+				// TODO: Require both down and up events.
+				if (context.taskIndex >= DsrKey::DsrKey_Unhandled - 1) {
+					context.finishTest(Grade::Passed);
+				} else {
+					context.passTask();
+					// Skip testing the escape key, because it is currently reserved for skipping tests.
+					if (context.taskIndex == DsrKey::DsrKey_Escape) {
+						context.passTask();
+					}
+				}
+			}
+		}
+	,
+		false
+	);
 }

--- a/Source/SDK/integrationTest/tests/inputTest.cpp
+++ b/Source/SDK/integrationTest/tests/inputTest.cpp
@@ -3,45 +3,50 @@
 
 using namespace dsr;
 
-void inputTests_populate(List<Test> &target) {
-	target.pushConstruct(
-		U"Mouse drag test"
-	,
-		[](AlignedImageRgbaU8 &canvas, TestContext &context) {
-			image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
-			if (context.taskIndex == 0) {
-				font_printLine(canvas, font_getDefault(), U"Hover the cursor over the window.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
-			} else if (context.taskIndex == 1) {
-				font_printLine(canvas, font_getDefault(), U"Press down the left mouse key.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
-			} else if (context.taskIndex == 2) {
-				font_printLine(canvas, font_getDefault(), U"Drag the mouse over the window with the left key pressed down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
-			} else if (context.taskIndex == 3) {
-				font_printLine(canvas, font_getDefault(), U"Release the left key.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+void inputTests_populate(List<Test> &target, int buttonCount, bool relative, bool verticalScroll) {
+	// TODO: Make notes about which tests were skipped and why.
+	if (buttonCount >= 1) {
+		target.pushConstruct(
+			U"Mouse drag test"
+		,
+			[](AlignedImageRgbaU8 &canvas, TestContext &context) {
+				image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
+				if (context.taskIndex == 0) {
+					font_printLine(canvas, font_getDefault(), U"Hover the cursor over the window.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (context.taskIndex == 1) {
+					font_printLine(canvas, font_getDefault(), U"Press down the left mouse key.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (context.taskIndex == 2) {
+					font_printLine(canvas, font_getDefault(), U"Drag the mouse over the window with the left key pressed down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (context.taskIndex == 3) {
+					font_printLine(canvas, font_getDefault(), U"Release the left key.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				}
 			}
-		}
-	,
-		[](const MouseEvent& event, TestContext &context) {
-			if (context.taskIndex == 0 && event.mouseEventType == MouseEventType::MouseMove && !context.leftMouseDown && !context.middleMouseDown && !context.rightMouseDown) {
-				context.passTask();
-			} else if (context.taskIndex == 1 && event.mouseEventType == MouseEventType::MouseDown) {
-				if (event.key == MouseKeyEnum::Left) {
+		,
+			[](const MouseEvent& event, TestContext &context) {
+				if (context.taskIndex == 0 && event.mouseEventType == MouseEventType::MouseMove && !context.leftMouseDown && !context.middleMouseDown && !context.rightMouseDown) {
 					context.passTask();
-				} else {
-					// TODO: Say which key was triggered instead and suggest skipping with escape if it can not be found.
-				}
-			} else if (context.taskIndex == 2 && event.mouseEventType == MouseEventType::MouseMove && context.leftMouseDown) {
-				context.passTask();
-			} else if (context.taskIndex == 3 && event.mouseEventType == MouseEventType::MouseUp) {
-				if (event.key == MouseKeyEnum::Left) {
-					context.finishTest(Grade::Passed);
-				} else {
-					// TODO: Say which key was triggered instead and suggest skipping with escape if it can not be found.
+				} else if (context.taskIndex == 1 && event.mouseEventType == MouseEventType::MouseDown) {
+					if (event.key == MouseKeyEnum::Left) {
+						context.passTask();
+					} else {
+						// TODO: Say which key was triggered instead and suggest skipping with escape if it can not be found.
+					}
+				} else if (context.taskIndex == 2 && event.mouseEventType == MouseEventType::MouseMove && context.leftMouseDown) {
+					context.passTask();
+				} else if (context.taskIndex == 3 && event.mouseEventType == MouseEventType::MouseUp) {
+					if (event.key == MouseKeyEnum::Left) {
+						context.finishTest(Grade::Passed);
+					} else {
+						// TODO: Say which key was triggered instead and suggest skipping with escape if it can not be found.
+					}
 				}
 			}
-		}
-	,
-		[](const KeyboardEvent& event, TestContext &context) {}
-	,
-		false
-	);
+		,
+			[](const KeyboardEvent& event, TestContext &context) {}
+		,
+			false
+		);
+	} else {
+		sendWarning(U"Skipped the left mouse button test, because 0 mouse buttons were selected as available.");
+	}
 }

--- a/Source/SDK/integrationTest/tests/inputTest.cpp
+++ b/Source/SDK/integrationTest/tests/inputTest.cpp
@@ -15,7 +15,7 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 				image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
 				context.drawAides(canvas);
 				if (TASK_IS(0)) {
-					font_printLine(canvas, font_getDefault(), U"Press down the left mouse button, .", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+					font_printLine(canvas, font_getDefault(), U"Press down the left mouse button.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				} else if (TASK_IS(1)) {
 					font_printLine(canvas, font_getDefault(), U"Release the left mouse button.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				} else if (TASK_IS(2)) {

--- a/Source/SDK/integrationTest/tests/inputTest.cpp
+++ b/Source/SDK/integrationTest/tests/inputTest.cpp
@@ -52,7 +52,56 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 			false
 		);
 	} else {
-		sendWarning(U"Skipped the left mouse button test, because no mouse buttons were told to be available in the call to inputTests_populate.");
+		sendWarning(U"Skipped the left mouse button test due to settings.");
+	}
+	if (buttonCount >= 1 && verticalScroll) {
+		target.pushConstruct(
+			U"Mouse scroll test"
+		,
+			[](AlignedImageRgbaU8 &canvas, TestContext &context) {
+				image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
+				// TODO: Show something moving in the background while scrolling to show the direction. Only pass once the end has been reached.
+				if (TASK_IS(0)) {
+					font_printLine(canvas, font_getDefault(), U"Scroll in the direction used to reach the top of a document by moving content down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (TASK_IS(1)) {
+					font_printLine(canvas, font_getDefault(), U"Click when you are down scrolling up.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (TASK_IS(2)) {
+					font_printLine(canvas, font_getDefault(), U"Scroll in the direction used to reach the bottom of a document by moving content up.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				} else if (TASK_IS(3)) {
+					font_printLine(canvas, font_getDefault(), U"Click when you are down scrolling down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+				}
+			}
+		,
+			[](const MouseEvent& event, TestContext &context) {
+				// Due to many laptops having the scroll direction inverted by default so that draging down scrolls up
+				// Comparing how scrolling works in external text editors would be a useful addition to this test,
+				// because many users probably don't know what is scrolling up and what is scrolling down when the direction is inverted on a track-pad.
+				if (TASK_IS(0) && EVENT_TYPE_IS(Scroll)) {
+					if (event.key == MouseKeyEnum::ScrollUp) {
+						context.passTask();
+					} else if (event.key == MouseKeyEnum::ScrollDown) {
+						// Just give a warning, because this test can be very
+						sendWarning(U"Scroll down was detected when attempting to scroll up. Compare the scrolling direction of a textbox with an external text editor to ensure consistent behavior.\n");
+					}
+				} else if (TASK_IS(1) && EVENT_TYPE_IS(MouseDown)) {
+					context.passTask();
+				} else if (TASK_IS(2) && EVENT_TYPE_IS(Scroll)) {
+					if (event.key == MouseKeyEnum::ScrollDown) {
+						context.passTask();
+					} else if (event.key == MouseKeyEnum::ScrollUp) {
+						sendWarning(U"Scroll up was detected when attempting to scroll down. Compare the scrolling direction of a textbox with an external text editor to ensure consistent behavior.\n");
+					}
+				} else if (TASK_IS(3) && EVENT_TYPE_IS(MouseDown)) {
+					context.finishTest(Grade::Passed);
+				}
+			}
+		,
+			[](const KeyboardEvent& event, TestContext &context) {}
+		,
+			false
+		);
+	} else {
+		sendWarning(U"Skipped the vertical scroll test due to settings.\n");
 	}
 	// TODO: Create tests for other mouse buttons by reusing code in functions.
 	// TODO: Create tests for keyboards, that display pressed physical keys on a QWERTY keyboard and unicode values of characters.

--- a/Source/SDK/integrationTest/tests/inputTest.cpp
+++ b/Source/SDK/integrationTest/tests/inputTest.cpp
@@ -13,6 +13,7 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 		,
 			[](AlignedImageRgbaU8 &canvas, TestContext &context) {
 				image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
+				context.drawAides(canvas);
 				if (TASK_IS(0)) {
 					font_printLine(canvas, font_getDefault(), U"Press down the left mouse button, .", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				} else if (TASK_IS(1)) {
@@ -62,7 +63,7 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 			false
 		);
 	} else {
-		sendWarning(U"Skipped the left mouse button test due to settings.");
+		sendWarning(U"Skipped the mouse button test due to settings.\n");
 	}
 
 	if (buttonCount >= 1) {
@@ -71,6 +72,7 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 		,
 			[](AlignedImageRgbaU8 &canvas, TestContext &context) {
 				image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
+				context.drawAides(canvas);
 				if (TASK_IS(0)) {
 					font_printLine(canvas, font_getDefault(), U"Hover the cursor over the window.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				} else if (TASK_IS(1)) {
@@ -110,7 +112,7 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 			false
 		);
 	} else {
-		sendWarning(U"Skipped the left mouse button test due to settings.");
+		sendWarning(U"Skipped the mouse button drag test due to settings.\n");
 	}
 	if (buttonCount >= 1 && verticalScroll) {
 		target.pushConstruct(
@@ -118,6 +120,7 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 		,
 			[](AlignedImageRgbaU8 &canvas, TestContext &context) {
 				image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
+				context.drawAides(canvas);
 				// TODO: Show something moving in the background while scrolling to show the direction. Only pass once the end has been reached.
 				if (TASK_IS(0)) {
 					font_printLine(canvas, font_getDefault(), U"Scroll in the direction used to reach the top of a document by moving content down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));

--- a/Source/SDK/integrationTest/tests/inputTest.cpp
+++ b/Source/SDK/integrationTest/tests/inputTest.cpp
@@ -1,0 +1,47 @@
+
+#include "inputTest.h"
+
+using namespace dsr;
+
+void inputTests_populate(List<Test> &target) {
+	target.pushConstruct(
+		U"Mouse drag test"
+	,
+		[](AlignedImageRgbaU8 &canvas, TestContext &context) {
+			image_fill(canvas, ColorRgbaI32(255, 255, 255, 255));
+			if (context.taskIndex == 0) {
+				font_printLine(canvas, font_getDefault(), U"Hover the cursor over the window.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+			} else if (context.taskIndex == 1) {
+				font_printLine(canvas, font_getDefault(), U"Press down the left mouse key.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+			} else if (context.taskIndex == 2) {
+				font_printLine(canvas, font_getDefault(), U"Drag the mouse over the window with the left key pressed down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+			} else if (context.taskIndex == 3) {
+				font_printLine(canvas, font_getDefault(), U"Release the left key.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+			}
+		}
+	,
+		[](const MouseEvent& event, TestContext &context) {
+			if (context.taskIndex == 0 && event.mouseEventType == MouseEventType::MouseMove && !context.leftMouseDown && !context.middleMouseDown && !context.rightMouseDown) {
+				context.passTask();
+			} else if (context.taskIndex == 1 && event.mouseEventType == MouseEventType::MouseDown) {
+				if (event.key == MouseKeyEnum::Left) {
+					context.passTask();
+				} else {
+					// TODO: Say which key was triggered instead and suggest skipping with escape if it can not be found.
+				}
+			} else if (context.taskIndex == 2 && event.mouseEventType == MouseEventType::MouseMove && context.leftMouseDown) {
+				context.passTask();
+			} else if (context.taskIndex == 3 && event.mouseEventType == MouseEventType::MouseUp) {
+				if (event.key == MouseKeyEnum::Left) {
+					context.finishTest(Grade::Passed);
+				} else {
+					// TODO: Say which key was triggered instead and suggest skipping with escape if it can not be found.
+				}
+			}
+		}
+	,
+		[](const KeyboardEvent& event, TestContext &context) {}
+	,
+		false
+	);
+}

--- a/Source/SDK/integrationTest/tests/inputTest.h
+++ b/Source/SDK/integrationTest/tests/inputTest.h
@@ -1,0 +1,9 @@
+
+#ifndef INPUT_TEST
+#define INPUT_TEST
+
+#include "../Test.h"
+
+void inputTests_populate(dsr::List<Test> &target);
+
+#endif

--- a/Source/SDK/integrationTest/tests/inputTest.h
+++ b/Source/SDK/integrationTest/tests/inputTest.h
@@ -4,6 +4,21 @@
 
 #include "../Test.h"
 
-void inputTests_populate(dsr::List<Test> &target);
+// buttonCount = 0 means that this test can not be performed at all.
+// buttonCount = 1 means that the test will only require access to the left mouse button. (physically the right button if swapped for left handed users)
+// buttonCount = 2 means that both left and right buttons are available, but not the middle button or clickable scroll wheel.
+// buttonCount = 3 means that all three mouse buttons (left, right and middle) are available.
+// While three buttons are available in the media layer, one should try to design applications to be useful even if only the left mouse button exists.
+// The right button and scroll wheel can add convenience when available to the user.
+// While more than three mouse buttons is not supported directly, they can still be bound as an extension to the keyboard using external settings.
+
+// relative = true means that the used input device applies an offset to the cursor, and then the cursor's location can be reassigned to a new location without conflicts. (mouse, stick, ball, trackpad)
+// relative = false means that the used input device sets an absolute cursor position from direct interaction with the screen, so that nothing else can move the cursor at the same time. (stylus pen, touch screen, eye-tracker)
+// Touch screens are assumed to allow light touch for hovering and hard touch for clicking, because this is essential for using desktop applications. Otherwise hover effects will be stuck on the last clicked location.
+
+// verticalScroll = true means that there exists a vertical scroll wheel or the two finger gesture to allow scrolling vertically. 
+// verticalScroll = false is used to skip all tests that require vertical scrolling.
+// Horizontal scrolling is currently not supported, because it mostly requires getting a laptop and the tests should be possible to complete with a three button mouse that can easily be moved around between computers.
+void inputTests_populate(dsr::List<Test> &target, int buttonCount = 3, bool relative = true, bool verticalScroll = true);
 
 #endif


### PR DESCRIPTION
Started an integration test in the SDK folder, but it might later be moved to a separate folder with different kinds of integration tests.

Also fixed Alt press, F10 press and cursor locations from scroll events on MS-Windows. AltGr is treated like Alt+Ctrl on Windows without any filtering of the duplicate events.

Most of the things are not yet tested. One could have different tests to run one at a time instead of everything in series (free style, exam style, long test, quick test...). Visuals showing pressed keys would help to see faster when things work as expected.