### PR TITLE
Minor fixes from compiling with CLANG again

### DIFF
--- a/Source/DFPSR/base/allocator.cpp
+++ b/Source/DFPSR/base/allocator.cpp
@@ -119,7 +119,7 @@ void* operator new(size_t contentSize) {
 			head = garbagePiles[bufferIndex].getAllocation();
 		}
 	allocationLock.unlock();
-    return getContent(head);
+	return getContent(head);
 }
 
 void operator delete(void* content) {
@@ -133,7 +133,7 @@ void operator delete(void* content) {
 			garbagePiles[bufferIndex].recycleAllocation(head);
 			//printf("Freed memory of size %li from size group %i\n", head->contentSize, bufferIndex);
 		}
-    allocationLock.unlock();
+	allocationLock.unlock();
 }
 
 #endif

--- a/Source/SDK/cube/Cube.DsrProj
+++ b/Source/SDK/cube/Cube.DsrProj
@@ -5,6 +5,9 @@ Graphics
 Crawl "main.cpp"
 Import "../../DFPSR/DFPSR.DsrHead"
 
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
 # If you don't want static linking of standard C/C++ libraries, you have to comment out StaticRuntime

--- a/Source/SDK/fileFinder/FileFinder.DsrProj
+++ b/Source/SDK/fileFinder/FileFinder.DsrProj
@@ -2,6 +2,9 @@
 CompilerFlag "-std=c++14"
 Crawl "main.cpp"
 
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
 # If you don't want static linking of standard C/C++ libraries, you have to comment out StaticRuntime

--- a/Source/SDK/guiExample/GuiExample.DsrProj
+++ b/Source/SDK/guiExample/GuiExample.DsrProj
@@ -5,6 +5,9 @@ Graphics
 Crawl "main.cpp"
 Import "../../DFPSR/DFPSR.DsrHead"
 
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
 # If you don't want static linking of standard C/C++ libraries, you have to comment out StaticRuntime

--- a/Source/SDK/integrationTest/IntegrationTest.DsrProj
+++ b/Source/SDK/integrationTest/IntegrationTest.DsrProj
@@ -5,6 +5,9 @@ Graphics
 Crawl "main.cpp"
 Import "../../DFPSR/DFPSR.DsrHead"
 
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
 # If you don't want static linking of standard C/C++ libraries, you have to comment out StaticRuntime

--- a/Source/SDK/sandbox/Sandbox.DsrProj
+++ b/Source/SDK/sandbox/Sandbox.DsrProj
@@ -3,6 +3,9 @@ ReuseMemory
 Graphics
 #Sound
 
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 # An include using quotation marks will detect the header and its headers recursively.
 # For each detected header, the build system looks for an implementation file of the same name in the same folder.
 # Because sandbox.cpp and tool.cpp don't have sandbox.h/hpp or tool.h/hpp, the build system can't know that main depends on them.

--- a/Source/SDK/terrain/Terrain.DsrProj
+++ b/Source/SDK/terrain/Terrain.DsrProj
@@ -5,6 +5,9 @@ Graphics
 Crawl "main.cpp"
 Import "../../DFPSR/DFPSR.DsrHead"
 
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
 # If you don't want static linking of standard C/C++ libraries, you have to comment out StaticRuntime

--- a/Source/templates/basic3D/Basic3D.DsrProj
+++ b/Source/templates/basic3D/Basic3D.DsrProj
@@ -5,6 +5,9 @@ Sound
 Crawl "main.cpp"
 Import "../../DFPSR/DFPSR.DsrHead"
 
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
 # If you don't want static linking of standard C/C++ libraries, you have to comment out StaticRuntime

--- a/Source/templates/basicCLI/BasicCLI.DsrProj
+++ b/Source/templates/basicCLI/BasicCLI.DsrProj
@@ -1,5 +1,9 @@
 ﻿# No need to import DFPSR.DsrHead with stub backends when only including essential headers.
 CompilerFlag "-std=c++14"
+
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 Crawl "main.cpp"
 
 # Linking statically to standard C/C++ libraries allow running the program without installing them.

--- a/Source/templates/basicGUI/BasicGUI.DsrProj
+++ b/Source/templates/basicGUI/BasicGUI.DsrProj
@@ -5,6 +5,9 @@ Sound
 Crawl "main.cpp"
 Import "../../DFPSR/DFPSR.DsrHead"
 
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
 # If you don't want static linking of standard C/C++ libraries, you have to comment out StaticRuntime

--- a/Source/tools/builder/buildProject.bat
+++ b/Source/tools/builder/buildProject.bat
@@ -38,7 +38,7 @@ if exist %BUILDER_EXECUTABLE% (
 ) else (
 	echo Building the Builder build system for first time use.
 	pushd %CPP_COMPILER_FOLDER%
-		%CPP_COMPILER_PATH% -o %BUILDER_EXECUTABLE% %BUILDER_SOURCE% -static -static-libgcc -static-libstdc++ -std=c++14
+		%CPP_COMPILER_PATH% -o %BUILDER_EXECUTABLE% %BUILDER_SOURCE% -static -static-libgcc -static-libstdc++ -std=c++14 -lstdc++
 	popd
 	if errorlevel 0 (
 		echo Completed building the Builder build system.

--- a/Source/tools/builder/buildProject.sh
+++ b/Source/tools/builder/buildProject.sh
@@ -1,7 +1,14 @@
 
 # Local build settings that should be configured before building for the first time.
 
+# Make sure to erase all objects in the temporary folder before changing compiler.
+
+# Compile using GCC's C++ compiler
 CPP_COMPILER_PATH="/usr/bin/g++"
+
+# Compile using CLANG (Needs a 'Link "stdc++"' command in each project)
+#CPP_COMPILER_PATH="/usr/bin/clang"
+
 echo "Change CPP_COMPILER_PATH in ${BUILDER_FOLDER}/buildProject.sh if you are not using ${CPP_COMPILER_PATH} as your compiler."
 
 # Change TEMPORARY_FOLDER if you don't want to recompile everything after each reboot, or your operating system has a different path to the temporary folder.
@@ -35,7 +42,7 @@ else
 	echo "Building the Builder build system for first time use."
 	LIBRARY_PATH="$(realpath ${BUILDER_FOLDER}/../../DFPSR)"
 	SOURCE_CODE="${BUILDER_FOLDER}/code/main.cpp ${BUILDER_FOLDER}/code/Machine.cpp ${BUILDER_FOLDER}/code/generator.cpp ${BUILDER_FOLDER}/code/analyzer.cpp ${BUILDER_FOLDER}/code/expression.cpp ${LIBRARY_PATH}/collection/collections.cpp ${LIBRARY_PATH}/api/fileAPI.cpp ${LIBRARY_PATH}/api/bufferAPI.cpp ${LIBRARY_PATH}/api/stringAPI.cpp ${LIBRARY_PATH}/api/timeAPI.cpp ${LIBRARY_PATH}/base/SafePointer.cpp"
-	"${CPP_COMPILER_PATH}" -o "${BUILDER_EXECUTABLE}" ${SOURCE_CODE} -std=c++14
+	"${CPP_COMPILER_PATH}" -o "${BUILDER_EXECUTABLE}" ${SOURCE_CODE} -std=c++14 -lstdc++
 	if [ $? -eq 0 ]; then
 		echo "Completed building the Builder build system."
 	else

--- a/Source/tools/builder/code/Machine.cpp
+++ b/Source/tools/builder/code/Machine.cpp
@@ -204,8 +204,8 @@ static void interpretLine(Machine &target, const List<String> &tokens, int64_t s
 				validateSettings(target, U"in target after adding a linker flag\n");
 			} else if (string_caseInsensitiveMatch(first, U"linkerflag")) {
 				// For linker flags that are not used to
-				target.compilerFlags.push(STRING_EXPR(startTokenIndex + 1, endTokenIndex));
-				validateSettings(target, U"in target after adding a compiler flag\n");
+				target.linkerFlags.push(STRING_EXPR(startTokenIndex + 1, endTokenIndex));
+				validateSettings(target, U"in target after adding a linker flag\n");
 			} else if (string_caseInsensitiveMatch(first, U"compilerflag")) {
 				target.compilerFlags.push(STRING_EXPR(startTokenIndex + 1, endTokenIndex));
 				validateSettings(target, U"in target after adding a compiler flag\n");

--- a/Source/tools/wizard/Wizard.DsrProj
+++ b/Source/tools/wizard/Wizard.DsrProj
@@ -18,6 +18,9 @@ Import "../../DFPSR/DFPSR.DsrHead"
 # The DFPSR library uses C++14 as a minimum requirement, but you can use newer versions as well.
 CompilerFlag "-std=c++14"
 
+# If compiling using CLANG instead of GCC in tools/builder/buildProject.sh, you need to include the C++ standard library explicitly.
+#Link "stdc++"
+
 # Linking statically to standard C/C++ libraries allow running the program without installing them.
 #   Recommended for making an installer for another application or programs that should not need an installer.
 # If you don't want static linking of standard C/C++ libraries, you have to comment out StaticRuntime

--- a/Source/windowManagers/Win32Window.cpp
+++ b/Source/windowManagers/Win32Window.cpp
@@ -95,8 +95,8 @@ public:
 	void redraw(HWND& hwnd, bool locked, bool swap); // HWND is passed by argument because drawing might be called before the constructor has assigned it to this->hwnd
 	void showCanvas() override;
 	// Clipboard		
-	dsr::ReadableString loadFromClipboard(double timeoutInSeconds);
-	void saveToClipboard(const dsr::ReadableString &text, double timeoutInSeconds);
+	dsr::ReadableString loadFromClipboard(double timeoutInSeconds) override;
+	void saveToClipboard(const dsr::ReadableString &text, double timeoutInSeconds) override;
 };
 
 static LRESULT CALLBACK WindowProcedure(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);

--- a/Source/windowManagers/X11Window.cpp
+++ b/Source/windowManagers/X11Window.cpp
@@ -107,8 +107,8 @@ public:
 	void listContentInClipboard();
 	void initializeClipboard();
 	void terminateClipboard();		
-	dsr::ReadableString loadFromClipboard(double timeoutInSeconds);
-	void saveToClipboard(const dsr::ReadableString &text, double timeoutInSeconds);
+	dsr::ReadableString loadFromClipboard(double timeoutInSeconds) override;
+	void saveToClipboard(const dsr::ReadableString &text, double timeoutInSeconds) override;
 };
 
 void X11Window::initializeClipboard() {


### PR DESCRIPTION
Fixed some minor style issues to reduce clutter with compiler warnings.

Fixed a bug in the builder build system.

Did not have access to MS-Windows to test building the builder build system with a flag for CLANG.