### PR TITLE
Clearing new heap memory

### DIFF
--- a/Source/DFPSR/api/bufferAPI.h
+++ b/Source/DFPSR/api/bufferAPI.h
@@ -58,7 +58,7 @@ namespace dsr {
 	using Buffer = std::shared_ptr<BufferImpl>;
 
 	// Side-effect: Creates a new buffer head regardless of newSize, but only allocates a zeroed data allocation if newSize > 0.
-	// Post-condition: Returns a handle to the new buffer.
+	// Post-condition: Returns a handle to the new buffer, which is initialized to zeroes.
 	// Creating a buffer without a size will only allocate the buffer's head referring to null data with size zero.
 	Buffer buffer_create(int64_t newSize);
 	// The buffer always allocate with DSR_MAXIMUM_ALIGNMENT, but you can check that your requested alignment is not too much.

--- a/Source/DFPSR/api/bufferAPI.h
+++ b/Source/DFPSR/api/bufferAPI.h
@@ -79,7 +79,7 @@ namespace dsr {
 	void buffer_replaceDestructor(const Buffer &buffer, const std::function<void(uint8_t *)>& newDestructor);
 
 	// Returns true iff buffer exists, even if it is empty without any data allocation.
-	inline bool buffer_exists(Buffer buffer) {
+	inline bool buffer_exists(const Buffer &buffer) {
 		return buffer.get() != nullptr;
 	}
 

--- a/Source/DFPSR/base/heap.cpp
+++ b/Source/DFPSR/base/heap.cpp
@@ -169,7 +169,7 @@ namespace dsr {
 
 	static HeapPool defaultHeap;
 
-	UnsafeAllocation heap_allocate(uintptr_t minimumSize) {
+	UnsafeAllocation heap_allocate(uintptr_t minimumSize, bool zeroed) {
 		int32_t binIndex = getBinIndex(minimumSize);
 		UnsafeAllocation result(nullptr, nullptr);
 		if (binIndex == -1) {
@@ -196,6 +196,9 @@ namespace dsr {
 				}
 			}
 			defaultHeap.poolLock.unlock();
+			if (zeroed && result.data != nullptr) {
+				memset(result.data, 0, paddedSize);
+			}
 		}
 		return result;
 	}

--- a/Source/DFPSR/base/heap.h
+++ b/Source/DFPSR/base/heap.h
@@ -28,9 +28,10 @@
 
 namespace dsr {
 	// Allocate memory in the heap.
-	//   The size argument is the minimum number of bytes to allocate, but the result may give you more than you asked for.
+	//   The minimumSize argument is the minimum number of bytes to allocate, but the result may give you more than you asked for.
+	//   When zeroed is true, the new memory will be zeroed. Otherwise it may contain uninitialized data.
 	// Post-condition: Returns pointers to the payload and header.
-	UnsafeAllocation heap_allocate(uint64_t minimumSize);
+	UnsafeAllocation heap_allocate(uint64_t minimumSize, bool zeroed = true);
 
 	// Pre-condition: The allocation pointer must point to the start of a payload allocated using heap_allocate, no offsets nor other allocators allowed.
 	// Post-condition: Returns the number of available bytes in the allocation.


### PR DESCRIPTION
Added an argument for clearing the newly allocated memory, which is enabled by default for safety. Then it can be disabled manually when you know that all data will soon be overwritten.