### PR TITLE
Refactored SIMD functions

### DIFF
--- a/Source/DFPSR/History.txt
+++ b/Source/DFPSR/History.txt
@@ -30,18 +30,19 @@ Changes from version 0.1.0 to version 0.2.0 (Bug fixes)
 	* If you used a custom theme before the system was finished, you will now have to add the assignment "filter = 1" for components where rounded edges became black from adding the filter setting.
 		Because one can not let default values depend on which component is used when theme classes are shared freely between components.
 
-Changes from version 0.2.0 to version 0.3.0 (Performance and safety improvements)
+Changes from version 0.2.0 to version 0.3.0 (Performance, safety and template improvements)
 	* To make SafePointer fully typesafe so that one can't accidentally give write access to write protected data, the recursive constness had to be removed.
 		Replace 'const SafePointer<' with 'SafePointer<const '
 		Replace 'const dsr::SafePointer<' with 'dsr::SafePointer<const '
 	* The function given to image_dangerous_replaceDestructor no longer frees the allocation itself, only external resources associated with the data.
 		Because heap_free is called automatically after the destructor in the new memory allocator.
 	* simd.h has moved into the dsr namespace because it was getting too big for the global namespace.
-		gather has been renamed into gather_U32, gather_I32 and gather_F32.
+		* gather has been renamed into gather_U32, gather_I32 and gather_F32.
 			This avoids potential ambiguity.
-		The 'a == b' and 'a != b' operators have been replaced with 'allLanesEqual(a, b)' and '!allLanesEqual(a, b)'.
+		* The 'a == b' and 'a != b' operators have been replaced with 'allLanesEqual(a, b)' and '!allLanesEqual(a, b)'.
 			This reserves the comparison operators for future use with multiple boolean results.
-		Immediate bit shifting now use the bitShiftLeftImmediate and bitShiftRightImmediate functions with a template argument for the number of bits to shift.
+		* Immediate bit shifting now use the bitShiftLeftImmediate and bitShiftRightImmediate functions with a template argument for the number of bits to shift.
+			Because it was very easy to forget that the offset had to be constant with some SIMD instructions.
 			Replace any << or >> operator that takes a constant offset with the new functions to prevent slowing down.
 				Replace a << 3 with bitShiftLeftImmediate<3>(a).
 				Replace a >> 5 with bitShiftRightImmediate<5>(a).
@@ -49,11 +50,14 @@ Changes from version 0.2.0 to version 0.3.0 (Performance and safety improvements
 				Replace a << b with a << U32x4(b), a << U16x8(b), a << U8x16(b), a << U32x8(b), a << U16x16(b), a << U8x32(b), a << U32xX(b), a << U16xX(b) or a << U8xX(b).
 				Replace a >> b with a >> U32x4(b), a >> U16x8(b), a >> U8x16(b), a >> U32x8(b), a >> U16x16(b), a >> U8x32(b), a >> U32xX(b), a >> U16xX(b) or a >> U8xX(b).
 				The more lanes you use, the slower it becomes when not available in SIMD hardware, so try to use at least 32-bit integers for faster fallback implementations.
-			If you know that the offset is always evenly divisible by 8, you can use byteShiftLeft and byteShiftRight instead.
-				Replace a << 8 with byteShiftLeft(a, 8).
-				Replace a >> 16 with byteShiftRight(a, 16).
-			This makes sure that one does not accidentally use an immediate bit shift with a variable offset.
-				Using a template argument for the offset also allow detecting offsets outside of the deterministic range in compile time.
+		* clamp, clampLower and clampUpper are global methods instead of member methods, to work the same for scalar operations in template functions.
+			Replace myVector.clamp(min, max) with clamp(VectorType(min), myVector, VectorType(max)).
+			Replace myVector.clampLower(min) with clampLower(VectorType(min), myVector).
+			Replace myVector.clampUpper(max) with clampUpper(myVector, VectorType(max)).
+		* reciprocal, reciprocalSquareRoot and squareRoot are now global functions, to work the same for scalar operations in template functions.
+			Replace myVector.reciprocal() with reciprocal(myVector).
+			Replace myVector.reciprocalSquareRoot() with reciprocalSquareRoot(myVector).
+			Replace myVector.squareRoot() with squareRoot(myVector).
 	* Textures have been separated from images to allow using them as separate value types.
 		Because it was very difficult to re-use internal texture sampling methods for custom rendering pipelines.
 		  Now images and textures have immutable value allocated heads and all side-effects are in the pixel buffers.		  
@@ -62,7 +66,7 @@ Changes from version 0.2.0 to version 0.3.0 (Performance and safety improvements
 		Replace 'image_generatePyramid' with 'texture_generatePyramid'.
 		Create a texture from the image using texture_create_RgbaU8 with the image and the number of resolutions.
 		  Then assign the texture instead of the image.
-s	* PackOrder.h has a new packOrder_ prefix for global functions to prevent naming conflicts.
+	* PackOrder.h has a new packOrder_ prefix for global functions to prevent naming conflicts.
 		Replace 'getRed' with 'packOrder_getRed'.
 		Replace 'getGreen' with 'packOrder_getGreen'.
 		Replace 'getBlue' with 'packOrder_getBlue'.

--- a/Source/DFPSR/base/DsrTraits.h
+++ b/Source/DFPSR/base/DsrTraits.h
@@ -90,6 +90,18 @@
 		DSR_DECLARE_PROPERTY(DsrTrait_Any_F32)
 		DSR_APPLY_PROPERTY(DsrTrait_Any_F32, float)
 
+		DSR_DECLARE_PROPERTY(DsrTrait_Any)
+		DSR_APPLY_PROPERTY(DsrTrait_Any,   int8_t)
+		DSR_APPLY_PROPERTY(DsrTrait_Any,  int16_t)
+		DSR_APPLY_PROPERTY(DsrTrait_Any,  int32_t)
+		DSR_APPLY_PROPERTY(DsrTrait_Any,  int64_t)
+		DSR_APPLY_PROPERTY(DsrTrait_Any,  uint8_t)
+		DSR_APPLY_PROPERTY(DsrTrait_Any, uint16_t)
+		DSR_APPLY_PROPERTY(DsrTrait_Any, uint32_t)
+		DSR_APPLY_PROPERTY(DsrTrait_Any, uint64_t)
+		DSR_APPLY_PROPERTY(DsrTrait_Any,    float)
+		DSR_APPLY_PROPERTY(DsrTrait_Any,   double)
+
 		DSR_DECLARE_PROPERTY(DsrTrait_Scalar_SignedInteger)
 		DSR_APPLY_PROPERTY(DsrTrait_Scalar_SignedInteger,  int8_t)
 		DSR_APPLY_PROPERTY(DsrTrait_Scalar_SignedInteger, int16_t)

--- a/Source/DFPSR/base/simd.h
+++ b/Source/DFPSR/base/simd.h
@@ -3506,7 +3506,7 @@
 	// Warning! Behavior depends on endianness.
 	inline U32x8 reinterpret_U32FromU16(const U16x16& vector) {
 		#if defined USE_256BIT_X_SIMD
-			return U32x4(REINTERPRET_U16_TO_U32_SIMD256(vector.v));
+			return U32x8(REINTERPRET_U16_TO_U32_SIMD256(vector.v));
 		#else
 			const uint32_t *source = (const uint32_t*)vector.scalars;
 			return U32x8(source[0], source[1], source[2], source[3], source[4], source[5], source[6], source[7]);

--- a/Source/DFPSR/base/simd3D.h
+++ b/Source/DFPSR/base/simd3D.h
@@ -72,10 +72,10 @@ inline SIMD_TYPE squareLength(const VECTOR_TYPE &v) { \
 	return dotProduct(v, v); \
 } \
 inline SIMD_TYPE length(const VECTOR_TYPE &v) { \
-	return squareLength(v).squareRoot(); \
+	return squareRoot(squareLength(v)); \
 } \
 inline VECTOR_TYPE normalize(const VECTOR_TYPE &v) { \
-	return v * squareLength(v).reciprocalSquareRoot(); \
+	return v * reciprocalSquareRoot(squareLength(v)); \
 }
 
 // These are the infix operations for 3D SIMD vectors F32x4x3, F32x8x3...
@@ -117,10 +117,10 @@ inline SIMD_TYPE squareLength(const VECTOR_TYPE &v) { \
 	return dotProduct(v, v); \
 } \
 inline SIMD_TYPE length(const VECTOR_TYPE &v) { \
-	return squareLength(v).squareRoot(); \
+	return squareRoot(squareLength(v)); \
 } \
 inline VECTOR_TYPE normalize(const VECTOR_TYPE &v) { \
-	return v * squareLength(v).reciprocalSquareRoot(); \
+	return v * reciprocalSquareRoot(squareLength(v)); \
 }
 
 // These are the available in-plaxe operations for 2D SIMD vectors F32x4x2, F32x8x2...

--- a/Source/DFPSR/image/PackOrder.h
+++ b/Source/DFPSR/image/PackOrder.h
@@ -27,9 +27,8 @@
 #include <cstdint>
 #include "Color.h"
 #include "../base/endian.h"
-#include "../base/DsrTraits.h"
+#include "../base/noSimd.h"
 #include "../api/stringAPI.h"
-#include "../math/scalar.h"
 
 namespace dsr {
 
@@ -185,17 +184,16 @@ U packOrder_packBytes(const U &s0, const U &s1, const U &s2, const U &s3, const 
 //   From F32x4 to U32x4
 //   From F32x8 to U32x8
 //   From F32xX to U32xX
-//   From F32xF to U32xF
 template<typename U, typename F, DSR_ENABLE_IF(
 	 DSR_CHECK_PROPERTY(DsrTrait_Any_U32, U)
   && DSR_CHECK_PROPERTY(DsrTrait_Any_F32, F)
 )>
 inline U packOrder_floatToSaturatedByte(const F &s0, const F &s1, const F &s2, const F &s3) {
 	return packOrder_packBytes(
-	  truncateToU32(s0.clamp(0.1f, 255.1f)),
-	  truncateToU32(s1.clamp(0.1f, 255.1f)),
-	  truncateToU32(s2.clamp(0.1f, 255.1f)),
-	  truncateToU32(s3.clamp(0.1f, 255.1f))
+	  truncateToU32(clampUpper(s0, F(255.1f))),
+	  truncateToU32(clampUpper(s1, F(255.1f))),
+	  truncateToU32(clampUpper(s2, F(255.1f))),
+	  truncateToU32(clampUpper(s3, F(255.1f)))
 	);
 }
 // Using a specified pack order
@@ -205,10 +203,10 @@ template<typename U, typename F, DSR_ENABLE_IF(
 )>
 inline U packOrder_floatToSaturatedByte(const F &s0, const F &s1, const F &s2, const F &s3, const PackOrder &order) {
 	return packOrder_packBytes(
-	  truncateToU32(s0.clamp(0.1f, 255.1f)),
-	  truncateToU32(s1.clamp(0.1f, 255.1f)),
-	  truncateToU32(s2.clamp(0.1f, 255.1f)),
-	  truncateToU32(s3.clamp(0.1f, 255.1f)),
+	  truncateToU32(clampUpper(s0, F(255.1f))),
+	  truncateToU32(clampUpper(s1, F(255.1f))),
+	  truncateToU32(clampUpper(s2, F(255.1f))),
+	  truncateToU32(clampUpper(s3, F(255.1f))),
 	  order
 	);
 }

--- a/Source/DFPSR/math/scalar.h
+++ b/Source/DFPSR/math/scalar.h
@@ -24,41 +24,9 @@
 #ifndef DFPSR_MATH_SCALAR
 #define DFPSR_MATH_SCALAR
 
-#include <cmath>
-#include "../base/DsrTraits.h"
+#include "../base/noSimd.h"
 
 namespace dsr {
-
-// A minimum function that can take more than two arguments.
-// Post-condition: Returns the smallest of all given values, which must be comparable using the < operator and have the same type.
-template <typename T, DSR_ENABLE_IF(DSR_CHECK_PROPERTY(DsrTrait_Scalar, T))>
-inline T min(const T &a, const T &b) {
-	return (a < b) ? a : b;
-}
-template <typename T, typename... TAIL, DSR_ENABLE_IF(DSR_CHECK_PROPERTY(DsrTrait_Scalar, T))>
-inline T min(const T &a, const T &b, TAIL... tail) {
-	return min(min(a, b), tail...);
-}
-
-// A maximum function that can take more than two arguments.
-// Post-condition: Returns the largest of all given values, which must be comparable using the > operator and have the same type.
-template <typename T, DSR_ENABLE_IF(DSR_CHECK_PROPERTY(DsrTrait_Scalar, T))>
-inline T max(const T &a, const T &b) {
-	return (a > b) ? a : b;
-}
-template <typename T, typename... TAIL, DSR_ENABLE_IF(DSR_CHECK_PROPERTY(DsrTrait_Scalar, T))>
-inline T max(const T &a, const T &b, TAIL... tail) {
-	return max(max(a, b), tail...);
-}
-
-// Pre-condition: minValue <= maxValue
-// Post-condition: Returns value clamped from minValue to maxValue.
-template <typename T, DSR_ENABLE_IF(DSR_CHECK_PROPERTY(DsrTrait_Scalar, T))>
-T clamp(const T &minValue, T value, const T &maxValue) {
-	if (value > maxValue) value = maxValue;
-	if (value < minValue) value = minValue;
-	return value;
-}
 
 // Returns a modulo b where 0 <= a < b
 template <typename I, typename U, DSR_ENABLE_IF(DSR_CHECK_PROPERTY(DsrTrait_Scalar_SignedInteger, I) && DSR_CHECK_PROPERTY(DsrTrait_Scalar_Integer, U))>

--- a/Source/DFPSR/render/shader/fillerTemplates.h
+++ b/Source/DFPSR/render/shader/fillerTemplates.h
@@ -224,7 +224,7 @@ inline void fillRowSuper(void *data, PixelShadingCallback pixelShaderFunction, S
 			FVector4D depth = vRecDepth.get();
 			// After linearly interpolating (1 / W, U / W, V / W) based on the affine weights...
 			// Divide 1 by 1 / W to get the linear depth W
-			F32x4 vLinearDepth = vRecDepth.reciprocal();
+			F32x4 vLinearDepth = reciprocal(vRecDepth);
 			// Multiply the vertex weights to the second and third edges with the depth to compensate for that we divided them by depth before interpolating.
 			F32x4 weightB = vRecU * vLinearDepth;
 			F32x4 weightC = vRecV * vLinearDepth;

--- a/Source/SDK/SpriteEngine/lightAPI.cpp
+++ b/Source/SDK/SpriteEngine/lightAPI.cpp
@@ -44,13 +44,13 @@ void directedLight(const FMatrix3x3& normalToWorldSpace, OrderedImageRgbaU8& lig
 				F32xXx3 negativeSurfaceNormal = unpackRgb_U32xX_to_F32xXx3(normalColor) - 128.0f;
 				// Calculate light intensity
 				//   Normalization and negation is already pre-multiplied into reverseLightDirection
-				F32xX intensity = dotProduct(negativeSurfaceNormal, reverseLightDirection).clampLower(0.0f);
+				F32xX intensity = clampLower(dotProduct(negativeSurfaceNormal, reverseLightDirection), F32xX(0.0f));
 				F32xX red = intensity * colorR;
 				F32xX green = intensity * colorG;
 				F32xX blue = intensity * colorB;
-				red = red.clampUpper(255.1f);
-				green = green.clampUpper(255.1f);
-				blue = blue.clampUpper(255.1f);
+				red = clampUpper(red, F32xX(255.1f));
+				green = clampUpper(green, F32xX(255.1f));
+				blue = clampUpper(blue, F32xX(255.1f));
 				// TODO: Let color packing handle arbitrary vector lengths.
 				U8xX light = reinterpret_U8FromU32(packOrder_packBytes(truncateToU32(red), truncateToU32(green), truncateToU32(blue)));
 				if (ADD_LIGHT) {
@@ -248,9 +248,9 @@ static void addPointLightSuper(const OrthoView& camera, const IVector2D& worldCe
 					F32xX red = intensity * colorR;
 					F32xX green = intensity * colorG;
 					F32xX blue = intensity * colorB;
-					red = red.clampUpper(255.1f);
-					green = green.clampUpper(255.1f);
-					blue = blue.clampUpper(255.1f);
+					red = clampUpper(red, F32xX(255.1f));
+					green = clampUpper(green, F32xX(255.1f));
+					blue = clampUpper(blue, F32xX(255.1f));
 					// Add light to the image
 					U8xX morelight = reinterpret_U8FromU32(packOrder_packBytes(truncateToU32(red), truncateToU32(green), truncateToU32(blue)));
 					addLight(lightPixel, morelight);
@@ -306,9 +306,9 @@ void blendLight(AlignedImageRgbaU8& colorBuffer, const OrderedImageRgbaU8& diffu
 				F32xX red = (floatFromU32(packOrder_getRed(diffuse)) * floatFromU32(packOrder_getRed(light))) * scale;
 				F32xX green = (floatFromU32(packOrder_getGreen(diffuse)) * floatFromU32(packOrder_getGreen(light))) * scale;
 				F32xX blue = (floatFromU32(packOrder_getBlue(diffuse)) * floatFromU32(packOrder_getBlue(light))) * scale;
-				red = red.clampUpper(255.1f);
-				green = green.clampUpper(255.1f);
-				blue = blue.clampUpper(255.1f);
+				red = clampUpper(red, F32xX(255.1f));
+				green = clampUpper(green, F32xX(255.1f));
+				blue = clampUpper(blue, F32xX(255.1f));
 				U32xX color = packOrder_packBytes(truncateToU32(red), truncateToU32(green), truncateToU32(blue), targetOrder);
 				color.writeAligned(targetPixel, "blendLight: writing color");
 				targetPixel += laneCountX_32Bit;

--- a/Source/soundManagers/AlsaSound.cpp
+++ b/Source/soundManagers/AlsaSound.cpp
@@ -90,8 +90,8 @@ bool sound_streamToSpeakers(int channels, int sampleRate, std::function<bool(Saf
 			// SIMD vectorized sound conversion with scaling and clamping to signed 16-bit integers.
 			F32x4 lowerFloats = F32x4::readAligned(floatData + t, "sound_streamToSpeakers: Reading lower floats");
 			F32x4 upperFloats = F32x4::readAligned(floatData + t + 4, "sound_streamToSpeakers: Reading upper floats");
-			I32x4 lowerInts = truncateToI32((lowerFloats * 32767.0f).clamp(-32768.0f, 32767.0f));
-			I32x4 upperInts = truncateToI32((upperFloats * 32767.0f).clamp(-32768.0f, 32767.0f));
+			I32x4 lowerInts = truncateToI32(clamp(F32x4(-32768.0f), lowerFloats * 32767.0f, F32x4(32767.0f)));
+			I32x4 upperInts = truncateToI32(clamp(F32x4(-32768.0f), upperFloats * 32767.0f, F32x4(32767.0f)));
 			// TODO: Create I16x8 SIMD vectors for processing sound as 16-bit integers?
 			//       Or just move unzip into simd.h with a fallback solution and remove simdExtra.h.
 			//       Or just implement reading and writing of 16-bit signed integers using multiple SIMD registers or smaller memory regions.

--- a/Source/soundManagers/WinMMSound.cpp
+++ b/Source/soundManagers/WinMMSound.cpp
@@ -107,8 +107,8 @@ bool sound_streamToSpeakers(int channels, int sampleRate, std::function<bool(Saf
 					// SIMD vectorized sound conversion with scaling and clamping to signed 16-bit integers.
 					F32x4 lowerFloats = F32x4::readAligned(floatData + t, "sound_streamToSpeakers: Reading lower floats");
 					F32x4 upperFloats = F32x4::readAligned(floatData + t + 4, "sound_streamToSpeakers: Reading upper floats");
-					I32x4 lowerInts = truncateToI32((lowerFloats * 32767.0f).clamp(-32768.0f, 32767.0f));
-					I32x4 upperInts = truncateToI32((upperFloats * 32767.0f).clamp(-32768.0f, 32767.0f));
+					I32x4 lowerInts = truncateToI32(clamp(F32x4(-32768.0f), lowerFloats * 32767.0f, F32x4(32767.0f)));
+					I32x4 upperInts = truncateToI32(clamp(F32x4(-32768.0f), upperFloats * 32767.0f, F32x4(32767.0f)));
 					// TODO: Create I16x8 SIMD vectors for processing sound as 16-bit integers?
 					//       Or just move unzip into simd.h with a fallback solution and remove simdExtra.h.
 					//       Or just implement reading and writing of 16-bit signed integers using multiple SIMD registers or smaller memory regions.

--- a/Source/test.sh
+++ b/Source/test.sh
@@ -5,7 +5,6 @@ TEMP_ROOT=${ROOT_PATH}/../../temporary
 CPP_VERSION=-std=c++14
 MODE="-DDEBUG"
 DEBUGGER="-g"
-#MODE="-msse2 -mssse3 -mavx2"
 O_LEVEL=-O2
 
 chmod +x ${ROOT_PATH}/tools/build.sh;

--- a/Source/test/tests/SimdTest.cpp
+++ b/Source/test/tests/SimdTest.cpp
@@ -3,6 +3,8 @@
 #include "../../DFPSR/base/simd.h"
 
 // TODO: Test: allLanesNotEqual, allLanesLesser, allLanesGreater, allLanesLesserOrEqual, allLanesGreaterOrEqual, reinterpret_U16FromU32, reinterpret_U32FromU16, operand ~
+// TODO: Test that truncateToU32 saturates to minimum and maximum values.
+// TODO: Test that truncateToI32 saturates to minimum and maximum values.
 
 START_TEST(Simd)
 	printText("\nSIMD test is compiled using:\n");
@@ -146,13 +148,13 @@ START_TEST(Simd)
 	ASSERT(allLanesEqual(U16x8(12, 0, 34, 0, 56, 0, 78, 0).get_U32(), U32x4(12, 34, 56, 78)));
 
 	// Reciprocal: 1 / x
-	ASSERT(allLanesEqual(F32x4(0.5f, 1.0f, 2.0f, 4.0f).reciprocal(), F32x4(2.0f, 1.0f, 0.5f, 0.25f)));
+	ASSERT(allLanesEqual(reciprocal(F32x4(0.5f, 1.0f, 2.0f, 4.0f)), F32x4(2.0f, 1.0f, 0.5f, 0.25f)));
 
 	// Square root: sqrt(x)
-	ASSERT(allLanesEqual(F32x4(1.0f, 4.0f, 9.0f, 100.0f).squareRoot(), F32x4(1.0f, 2.0f, 3.0f, 10.0f)));
+	ASSERT(allLanesEqual(squareRoot(F32x4(1.0f, 4.0f, 9.0f, 100.0f)), F32x4(1.0f, 2.0f, 3.0f, 10.0f)));
 
 	// Reciprocal square root: 1 / sqrt(x)
-	ASSERT(allLanesEqual(F32x4(1.0f, 4.0f, 16.0f, 100.0f).reciprocalSquareRoot(), F32x4(1.0f, 0.5f, 0.25f, 0.1f)));
+	ASSERT(allLanesEqual(reciprocalSquareRoot(F32x4(1.0f, 4.0f, 16.0f, 100.0f)), F32x4(1.0f, 0.5f, 0.25f, 0.1f)));
 
 	// Minimum
 	ASSERT(allLanesEqual(min(F32x4(1.1f, 2.2f, 3.3f, 4.4f), F32x4(5.0f, 3.0f, 1.0f, -1.0f)), F32x4(1.1f, 2.2f, 1.0f, -1.0f)));
@@ -161,7 +163,9 @@ START_TEST(Simd)
 	ASSERT(allLanesEqual(max(F32x4(1.1f, 2.2f, 3.3f, 4.4f), F32x4(5.0f, 3.0f, 1.0f, -1.0f)), F32x4(5.0f, 3.0f, 3.3f, 4.4f)));
 
 	// Clamp
-	ASSERT(allLanesEqual(F32x4(-35.1f, 1.0f, 2.0f, 45.7f).clamp(-1.5f, 1.5f), F32x4(-1.5f, 1.0f, 1.5f, 1.5f)));
+	ASSERT(allLanesEqual(clamp(F32x4(-1.5f), F32x4(-35.1f, 1.0f, 2.0f, 45.7f), F32x4(1.5f)), F32x4(-1.5f, 1.0f, 1.5f, 1.5f)));
+	ASSERT(allLanesEqual(clampUpper(F32x4(-35.1f, 1.0f, 2.0f, 45.7f), F32x4(1.5f)), F32x4(-35.1f, 1.0f, 1.5f, 1.5f)));
+	ASSERT(allLanesEqual(clampLower(F32x4(-1.5f), F32x4(-35.1f, 1.0f, 2.0f, 45.7f)), F32x4(-1.5f, 1.0f, 2.0f, 45.7f)));
 
 	// F32x4 operations
 	ASSERT(allLanesEqual(F32x4(1.1f, -2.2f, 3.3f, 4.0f) + F32x4(2.2f, -4.4f, 6.6f, 8.0f), F32x4(3.3f, -6.6f, 9.9f, 12.0f)));
@@ -428,13 +432,13 @@ START_TEST(Simd)
 	ASSERT(allLanesEqual(U16x16(12, 0, 34, 0, 56, 0, 78, 0, 11, 0, 22, 0, 33, 0, 44, 2).get_U32(), U32x8(12, 34, 56, 78, 11, 22, 33, 131116)));
 
 	// Reciprocal: 1 / x
-	ASSERT(allLanesEqual(F32x8(0.5f, 1.0f, 2.0f, 4.0f, 8.0f, 10.0f, 100.0f, 1000.0f).reciprocal(), F32x8(2.0f, 1.0f, 0.5f, 0.25f, 0.125f, 0.1f, 0.01f, 0.001f)));
+	ASSERT(allLanesEqual(reciprocal(F32x8(0.5f, 1.0f, 2.0f, 4.0f, 8.0f, 10.0f, 100.0f, 1000.0f)), F32x8(2.0f, 1.0f, 0.5f, 0.25f, 0.125f, 0.1f, 0.01f, 0.001f)));
 
 	// Square root: sqrt(x)
-	ASSERT(allLanesEqual(F32x8(1.0f, 4.0f, 9.0f, 100.0f, 64.0f, 256.0f, 1024.0f, 4096.0f).squareRoot(), F32x8(1.0f, 2.0f, 3.0f, 10.0f, 8.0f, 16.0f, 32.0f, 64.0f)));
+	ASSERT(allLanesEqual(squareRoot(F32x8(1.0f, 4.0f, 9.0f, 100.0f, 64.0f, 256.0f, 1024.0f, 4096.0f)), F32x8(1.0f, 2.0f, 3.0f, 10.0f, 8.0f, 16.0f, 32.0f, 64.0f)));
 
 	// Reciprocal square root: 1 / sqrt(x)
-	ASSERT(allLanesEqual(F32x8(1.0f, 4.0f, 16.0f, 100.0f, 400.0f, 64.0f, 25.0f, 100.0f).reciprocalSquareRoot(), F32x8(1.0f, 0.5f, 0.25f, 0.1f, 0.05f, 0.125f, 0.2f, 0.1f)));
+	ASSERT(allLanesEqual(reciprocalSquareRoot(F32x8(1.0f, 4.0f, 16.0f, 100.0f, 400.0f, 64.0f, 25.0f, 100.0f)), F32x8(1.0f, 0.5f, 0.25f, 0.1f, 0.05f, 0.125f, 0.2f, 0.1f)));
 
 	// Minimum
 	ASSERT(allLanesEqual(min(F32x8(1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f, 8.8f), F32x8(5.0f, 3.0f, 1.0f, -1.0f, 4.0f, 5.0f, -2.5f, 10.0f)), F32x8(1.1f, 2.2f, 1.0f, -1.0f, 4.0f, 5.0f, -2.5f, 8.8f)));
@@ -443,7 +447,9 @@ START_TEST(Simd)
 	ASSERT(allLanesEqual(max(F32x8(1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f, 8.8f), F32x8(5.0f, 3.0f, 1.0f, -1.0f, 4.0f, 5.0f, -2.5f, 10.0f)), F32x8(5.0f, 3.0f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f, 10.0f)));
 
 	// Clamp
-	ASSERT(allLanesEqual(F32x8(-35.1f, 1.0f, 2.0f, 45.7f, 0.0f, -1.0f, 2.1f, -1.9f).clamp(-1.5f, 1.5f), F32x8(-1.5f, 1.0f, 1.5f, 1.5f, 0.0f, -1.0f, 1.5f, -1.5f)));
+	ASSERT(allLanesEqual(clamp(F32x8(-1.5f), F32x8(-35.1f, 1.0f, 2.0f, 45.7f, 0.0f, -1.0f, 2.1f, -1.9f), F32x8(1.5f)), F32x8(-1.5f, 1.0f, 1.5f, 1.5f, 0.0f, -1.0f, 1.5f, -1.5f)));
+	ASSERT(allLanesEqual(clampUpper(F32x8(-35.1f, 1.0f, 2.0f, 45.7f, 0.0f, -1.0f, 2.1f, -1.9f), F32x8(1.5f)), F32x8(-35.1f, 1.0f, 1.5f, 1.5f, 0.0f, -1.0f, 1.5f, -1.9f)));
+	ASSERT(allLanesEqual(clampLower(F32x8(-1.5f), F32x8(-35.1f, 1.0f, 2.0f, 45.7f, 0.0f, -1.0f, 2.1f, -1.9f)), F32x8(-1.5f, 1.0f, 2.0f, 45.7f, 0.0f, -1.0f, 2.1f, -1.5f)));
 
 	// F32x8 operations
 	ASSERT(allLanesEqual(F32x8(1.1f, -2.2f, 3.3f, 4.0f, 1.4f, 2.3f, 3.2f, 4.1f) + F32x8(2.2f, -4.4f, 6.6f, 8.0f, 4.11f, 3.22f, 2.33f, 1.44f), F32x8(3.3f, -6.6f, 9.9f, 12.0f, 5.51f, 5.52f, 5.53f, 5.54f)));


### PR DESCRIPTION
Made math member methods in SIMD vectors into global functions to make it easier to write template functions working with both vectors and single elements. This allow exposing an inlined function in a header with noSimd.h, and then use with SIMD vectors only when simd.h is included elsewhere.