### PR TITLE
Getting cache line width at runtime

### DIFF
--- a/Doc/Generator/Input/StyleGuide.txt
+++ b/Doc/Generator/Input/StyleGuide.txt
@@ -4,42 +4,50 @@ Title: Code convention for David Forsgren Piuva's Software Renderer
 
 To keep the style consistent, the style being used in the library is explained in this document.
 ---
-1. Use common sense! If it looks wrong to human readers then it's wrong. Don't defeat the purpose of any rule by taking it too far.
+1. Tabs for indentation then spaces for alignment. It's the best of both worlds by both having variable length tabs	and correct alignment that works between lines of the same indentation.
 ---
-2. Don't use iterators when there is any other way to accomplish the task. You can't write efficient algorithms without knowing the data structures.
+2. No new line for opening brackets.
+Makes the code more compact and decreases the risk of copy-paste errors.
 ---
-3. Tabs for indentation then spaces for alignment. It's the best of both worlds by both having variable length tabs	and correct alignment that works between lines of the same indentation.
+3. No hpp extensions, use h for all headers. Could be either way, but this library uses *.h for compact naming, so keep it consistent.
 ---
-4. No dangling else, use explicit {} for safety. Otherwise someone might add an extra statement and get random crashes.
----
-5. No hpp extensions, use h for all headers. Could be either way, but this library uses *.h for compact naming, so keep it consistent.
----
-6. C-style casting for raw data manipulation and C++-style for high-level classes.
+4. C-style casting for raw data manipulation and C++-style for high-level classes when possible.
 When using assembly intrinsics and raw pointer manipulation to alter the state of bits,
 verbose high-level abstractions only make it harder to count CPU cycles in your head.
 Always use the tool that makes sense for the problem you're trying to solve.
 C++ style is for things that are abstracted on a higher level.
 C style is for when a byte is just a byte and you just want to manipulate it in a specific way.
 ---
-7. Don't call member methods with "this" set to nullptr.
-This would be undefined behavior and may randomly crash.
-Use global functions instead. They allow checking pointers for null
-because they are explicit arguments declared by the programmer.
+5. Follow the most relevant standard without making contemporary assumptions.
+For code not intended for a specific system, follow the C++ standard.
+For code targeting a certain hardware using intrinsic functions, follow the hardware's standard.
+For code targeting a certain operating system, follow the operating system's standard.
 ---
-8. Avoid using STD/STL directly in SDK examples.
-Exposing types from the standard library should be done using an alias or wrapper in the dsr namespace.
-This allow replacing the standard library without breaking backward compatibility.
-The C++ standard libraries have broken backward compatibility before and it can happen again.
+6. Do not assume that a type has a certain size or format unless it is specified explicitly.
+The int type is not always 32 bits, so only use when 16 bits are enough, use int32_t for a signed 32-bit integer.
+Fixed integers such as uint8_t, uint16_t, uint32_t, uint64_t, int32_t and int64_t are preferred.
+For bit manipulation, use unsigned integers to avoid depending on two's complement.
+The char type is usually 8 bits large, but it is not specified by the C++ standard, so use uint8_t instead for buffers and DsrChar for 32-bit Unicode characters.
+The float type does not have to be any of the IEEE standards according to the C++ standard, but you can assume properties that are specified in a relevant standard.
+std::string is not used, because it has an undefined character encoding, so use dsr::String or dsr::ReadableString with UTF-32 instead.
+char* should only be used for constant string literals and interfacing with external libraries.
 ---
-9. Don't abuse the auto keyword everywhere just to make it look more "modern".
-Explicit type safety is what makes compiled languages safer than scripting.
+7. The code should work for both little-endian and big-endian, because both still exist.
+You may however ignore mixed-endian.
 ---
-10. No new line for opening brackets.
-Makes the code more compact and decreases the risk of copy-paste errors.
+8. Do not call member methods with "this" set to null, because that is undefined behavior.
 ---
-11. Don't fix the style of someone else's code if you can easily read it.
-Especially if there's no style rule explicitly supporting the change.
-Otherwise style changes will defeat the purpose by introducing more version conflicts.
+9. Avoid mixing side-effects with expressions for determinism across compilers.
+Non-deterministic expressions such as ((x++ - ++x) * x--) should never be used, so use ++ and -- in separate statements.
+Side-effects within the same depth of an expressions may be evaluated in any order because it is not specified in C++.
+Checking the return value of a function with side-effects is okay, because the side effect always come before returning the result in the called function.
+Lazy evaluation such as x != nullptr && foo(x) is okay, because lazy evaluation is well specified as only evaluating the right hand side when needed.
+Call chaining such as constructor(args).setSomeValue(value).setSomeOtherValue(value) is okay, because the execution order is explicit from differences in expression depth.
 ---
-12. Don't change things that you don't know how to test.
+10. Use the std library as little as possible.
+Each compiler, operating system and standard library implementation has subtle differences in how things work, which can cause programs to break on another computer.
+The goal of this framework is to make things more consistent across platforms, so that code that works on one computer is more likely to work on another computer.
+---
+11. Don't over-use the auto keyword.
+Spelling out the type explicitly makes the code easier to read.
 ---

--- a/Source/DFPSR/api/bufferAPI.cpp
+++ b/Source/DFPSR/api/bufferAPI.cpp
@@ -26,6 +26,7 @@
 #include "stringAPI.h"
 #include "../implementation/math/scalar.h"
 #include "../base/SafePointer.h"
+#include "../base/heap.h"
 
 namespace dsr {
 
@@ -35,9 +36,9 @@ Buffer buffer_create(intptr_t newSize) {
 	return handle_createArray<uint8_t>(AllocationInitialization::Zeroed, (uintptr_t)newSize);
 }
 
-Buffer buffer_create(intptr_t newSize, int paddToAlignment) {
+Buffer buffer_create(intptr_t newSize, uintptr_t paddToAlignment) {
 	if (newSize < 0) newSize = 0;
-	if (paddToAlignment > DSR_MAXIMUM_ALIGNMENT) {
+	if (paddToAlignment > heap_getHeapAlignment()) {
 		throwError(U"Maximum alignment exceeded when creating a buffer!\n");
 		return Handle<uint8_t>();
 	} else {

--- a/Source/DFPSR/api/bufferAPI.h
+++ b/Source/DFPSR/api/bufferAPI.h
@@ -61,9 +61,9 @@ namespace dsr {
 	Buffer buffer_create(intptr_t newSize);
 
 	// Allocate a Buffer with padding.
-	// The buffer always align the start with DSR_MAXIMUM_ALIGNMENT, but this function makes sure that paddToAlignment does not exceed DSR_MAXIMUM_ALIGNMENT.
-	// Pre-condition: paddToAlignment <= DSR_MAXIMUM_ALIGNMENT
-	Buffer buffer_create(intptr_t newSize, int paddToAlignment);
+	// The buffer always align the start with heap alignment, but this function makes sure that paddToAlignment does not exceed heap alignment.
+	// Pre-condition: paddToAlignment <= heap_getHeapAlignment()
+	Buffer buffer_create(intptr_t newSize, uintptr_t paddToAlignment);
 
 	// Sets the allocation's destructor, to be called when there are no more reference counted pointers to the buffer.
 	//   The destructor is not responsible for freeing the memory allocation itself, only calling destructors in the content.

--- a/Source/DFPSR/api/fileAPI.h
+++ b/Source/DFPSR/api/fileAPI.h
@@ -27,9 +27,7 @@
 #include "stringAPI.h"
 #include "bufferAPI.h"
 #include "../base/Handle.h"
-#if defined(WIN32) || defined(_WIN32)
-	#define USE_MICROSOFT_WINDOWS
-#endif
+#include "../settings.h"
 
 // The file API exists to save and load buffers of data for any type of file.
 // Any file format that is implemented against the Buffer type instead of hardcoding against the file stream can easily be
@@ -38,12 +36,14 @@
 namespace dsr {
 	// The PathSyntax enum allow processing theoreical paths for other operating systems than the local.
 	enum class PathSyntax { Windows, Posix };
-	#ifdef USE_MICROSOFT_WINDOWS
+	#if defined(USE_MICROSOFT_WINDOWS)
 		// Let the local syntax be for Windows.
 		#define LOCAL_PATH_SYNTAX dsr::PathSyntax::Windows
-	#else
+	#elif defined(USE_POSIX)
 		// Let the local syntax be for Posix.
 		#define LOCAL_PATH_SYNTAX dsr::PathSyntax::Posix
+	#else
+		#error "The target platform was not recognized as one of the supported operating systems in the file API!\n"
 	#endif
 
 	// Define NO_IMPLICIT_PATH_SYNTAX before including the header if you want all PathSyntax arguments to be explicit.

--- a/Source/DFPSR/api/imageAPI.cpp
+++ b/Source/DFPSR/api/imageAPI.cpp
@@ -47,7 +47,7 @@ IMAGE_TYPE image_create_template(const char * name, int32_t width, int32_t heigh
 	} else {
 		static const int32_t pixelSize = image_getPixelSize<IMAGE_TYPE>();
 		// Calculate the stride.
-		uintptr_t byteStride = memory_getPaddedSize(width * pixelSize, DSR_MAXIMUM_ALIGNMENT);
+		uintptr_t byteStride = memory_getPaddedSize(width * pixelSize, heap_getHeapAlignment());
 		uint32_t pixelStride = byteStride / pixelSize;
 		// Create the image.
 		return IMAGE_TYPE(buffer_create(byteStride * height).setName(name), 0, width, height, pixelStride, packOrderIndex);

--- a/Source/DFPSR/base/heap.h
+++ b/Source/DFPSR/base/heap.h
@@ -64,7 +64,7 @@ namespace dsr {
 		void heap_setAllocationName(void * const allocation, const char *name);
 		// Get the ascii name of allocation, or "none" if allocation is nullptr.
 		const char * heap_getAllocationName(void * const allocation);
-		// Gets the size padded out to whole blocks of DSR_MAXIMUM_ALIGNMENT, for constructing a SafePointer.
+		// Gets the size padded out to whole blocks of heap alignment, for constructing a SafePointer.
 		uintptr_t heap_getPaddedSize(void const * const allocation);
 	#endif
 
@@ -129,6 +129,9 @@ namespace dsr {
 	//                 To use more memory than requested, you must round it down to whole elements.
 	//                 If the element's size is a power of two, you can pre-compute a bit mask using memory_createAlignmentAndMask for rounding down.
 	uintptr_t heap_getAllocationSize(void const * const allocation);
+
+	// Get the alignment of the heap, which depends on the largest cache line size.
+	uintptr_t heap_getHeapAlignment();
 
 	// Pre-condition: The allocation pointer must point to the start of a payload allocated using heap_allocate, no offsets nor other allocators allowed.
 	// Post-condition: Returns a pointer to the heap allocation's header, which is used to construct safe pointers.

--- a/Source/DFPSR/base/simd.h
+++ b/Source/DFPSR/base/simd.h
@@ -91,6 +91,8 @@
 	#include "../settings.h"
 	#include "../base/noSimd.h"
 
+	namespace dsr {
+
 	// Alignment in bytes
 	#define ALIGN_BYTES(SIZE)  __attribute__((aligned(SIZE)))
 	#define ALIGN16 ALIGN_BYTES(16) // 128-bit alignment
@@ -98,8 +100,6 @@
 	#define ALIGN64 ALIGN_BYTES(64) // 512-bit alignment
 	#define ALIGN128 ALIGN_BYTES(128) // 1024-bit alignment
 	#define ALIGN256 ALIGN_BYTES(256) // 2048-bit alignment
-
-	namespace dsr {
 
 	// Everything declared in here handles things specific for SSE.
 	// Direct use of the macros will not provide portability to all hardware.

--- a/Source/README.md
+++ b/Source/README.md
@@ -1,0 +1,17 @@
+# Source folder
+The source folder contains the framework, system dependent backends, code examples and tools.
+
+## System dependent code
+Some of the code depends on different hardware and operating systems to abstract them away.
+
+* Source/DFPSR/api/fileAPI: The file API is implemented to hande file access on different operating systems.
+
+* Source/DFPSR/base/simd.h: The simd.h header is a SIMD abstraction layer that works without SIMD but can become faster for specific processor architectures by implementing the features.
+
+* Source/DFPSR/base/heap.cpp: The getCacheLineSize function depends on the operating system to get the cache line width for memory alignment, because aligning with cache lines is needed for thread safety and getting cache line width directly from hardware would require contemporary inline assembler hacks that will not work for future generations of hardware.
+
+* Source/windowManagers: Contains the integrations for displaying graphics and getting mouse and keyboard input on specific operating systems.
+These are selected based on the operating system in Source/DFPSR/DFPSR.DsrHead
+
+* Source/soundManagers: Contains the integrations for sound on specific operating systems.
+These are selected based on the operating system in Source/DFPSR/DFPSR.DsrHead

--- a/Source/test/tests/ImageTest.cpp
+++ b/Source/test/tests/ImageTest.cpp
@@ -10,7 +10,7 @@ START_TEST(Image)
 		ASSERT_EQUAL(image_useCount(imageA), 1);
 		ASSERT_EQUAL(image_getWidth(imageA), 17);
 		ASSERT_EQUAL(image_getHeight(imageA), 9);
-		ASSERT_EQUAL(image_getStride(imageA), 64);
+		ASSERT_EQUAL(image_getStride(imageA), heap_getHeapAlignment());
 		ASSERT_EQUAL(image_getBound(imageA), IRect(0, 0, 17, 9));
 		ImageU8 imageB; // Create empty image reference
 		ASSERT_EQUAL(image_useCount(imageA), 1);
@@ -30,7 +30,7 @@ START_TEST(Image)
 		ASSERT_EQUAL(image_useCount(image), 1);
 		ASSERT_EQUAL(image_getWidth(image), 3);
 		ASSERT_EQUAL(image_getHeight(image), 48);
-		ASSERT_EQUAL(image_getStride(image), 64);
+		ASSERT_EQUAL(image_getStride(image), heap_getHeapAlignment());
 		ASSERT_EQUAL(image_getBound(image), IRect(0, 0, 3, 48));
 	}
 	{ // ImageRgbaU8
@@ -41,7 +41,6 @@ START_TEST(Image)
 		ASSERT_EQUAL(image_useCount(image), 1);
 		ASSERT_EQUAL(image_getWidth(image), 52);
 		ASSERT_EQUAL(image_getHeight(image), 12);
-		ASSERT_EQUAL(image_getStride(image), 256);
 		ASSERT_EQUAL(image_getBound(image), IRect(0, 0, 52, 12));
 	}
 	{ // Sub-images


### PR DESCRIPTION
Lots of things will have to be optimized to use header pointers directly when the offset between allocation head and payload is no longer constant.