### PR TITLE
Removed std::vector from dsr::List

### DIFF
--- a/Source/DFPSR/api/stringAPI.cpp
+++ b/Source/DFPSR/api/stringAPI.cpp
@@ -73,8 +73,6 @@ ReadableString::ReadableString(const String& source)
 String::String() {}
 String::String(const char* source) { atomic_append_ascii(*this, source); }
 String::String(const DsrChar* source) { atomic_append_utf32(*this, source); }
-String::String(const String& source)
-: ReadableString(source.characters, source.view){}
 String::String(const ReadableString& source)
 : ReadableString(source.characters, source.view) {}
 

--- a/Source/DFPSR/api/stringAPI.h
+++ b/Source/DFPSR/api/stringAPI.h
@@ -123,8 +123,6 @@ public:
 	: characters(characters), view(view) {}
 	// Create from String by sharing the buffer
 	ReadableString(const String& source);
-	// Destructor
-	~ReadableString() {} // Do not override the non-virtual destructor.
 };
 
 // A safe and simple string type
@@ -143,7 +141,6 @@ public:
 	String(const char* source);
 	String(const DsrChar* source);
 	String(const ReadableString& source);
-	String(const String& source);
 };
 
 // Used as format tags around numbers passed to string_append or string_combine

--- a/Source/DFPSR/base/DsrTraits.h
+++ b/Source/DFPSR/base/DsrTraits.h
@@ -78,6 +78,7 @@
 
 		// Checking types.
 		#define DSR_SAME_TYPE(TYPE_A, TYPE_B) DsrTrait_SameType<TYPE_A, TYPE_B>::value
+		#define DSR_CONVERTIBLE_TO(FROM, TO) std::is_convertible<FROM, TO>::value
 		#define DSR_UTF32_LITERAL(TYPE) std::is_convertible<TYPE, const char32_t*>::value
 		#define DSR_ASCII_LITERAL(TYPE) std::is_convertible<TYPE, const char*>::value
 		#define DSR_INHERITS_FROM(DERIVED, BASE) std::is_base_of<BASE, DERIVED>::value

--- a/Source/DFPSR/base/heap.h
+++ b/Source/DFPSR/base/heap.h
@@ -81,10 +81,12 @@ namespace dsr {
 	// Increase the use count of an allocation.
 	//   Does nothing if the allocation is nullptr.
 	void heap_increaseUseCount(void const * const allocation);
+	void heap_increaseUseCount(AllocationHeader const * const header);
 
 	// Decrease the use count of an allocation and recycle it when reaching zero.
 	//   Does nothing if the allocation is nullptr.
 	void heap_decreaseUseCount(void const * const allocation);
+	void heap_decreaseUseCount(AllocationHeader const * const header);
 
 	// Pre-condition:
 	//   allocation points to memory allocated as heap_allocate(...).data because this feature is specific to this allocator.
@@ -92,6 +94,7 @@ namespace dsr {
 	//   Returns the number of bytes in the allocation that are actually used, which is used for tight bound checks and knowing how large a buffer is.
 	//   Returns 0 if allocation is nullptr.
 	uintptr_t heap_getUsedSize(void const * const allocation);
+	uintptr_t heap_getUsedSize(AllocationHeader const * const header);
 
 	// Side-effect:
 	//   Assigns a new used size to allocation.
@@ -103,6 +106,7 @@ namespace dsr {
 	// Post-condition:
 	//   Returns the assigned size, which is the given size, an exceeded allocation size, or zero for an allocation that does not exist.
 	uintptr_t heap_setUsedSize(void * const allocation, uintptr_t size);
+	uintptr_t heap_setUsedSize(AllocationHeader * const header, uintptr_t size);
 
 	// A function pointer for destructors.
 	using HeapDestructorPointer = void(*)(void *toDestroy, void *externalResource);
@@ -122,13 +126,14 @@ namespace dsr {
 
 	// Get the use count outside of transactions without locking.
 	uintptr_t heap_getUseCount(void const * const allocation);
+	uintptr_t heap_getUseCount(AllocationHeader const * const header);
 
 	// Pre-condition: The allocation pointer must point to the start of a payload allocated using heap_allocate, no offsets nor other allocators allowed.
 	// Post-condition: Returns the number of available bytes in the allocation.
-	//                 You may not read a single byte outside of it, because it might include padding that ends at uneven addresses.
-	//                 To use more memory than requested, you must round it down to whole elements.
-	//                 If the element's size is a power of two, you can pre-compute a bit mask using memory_createAlignmentAndMask for rounding down.
 	uintptr_t heap_getAllocationSize(void const * const allocation);
+	// Pre-condition: The header pointer must point to the allocation head, as returned from heap_allocate or heap_getHeader.
+	// Post-condition: Returns the number of available bytes in the allocation.
+	uintptr_t heap_getAllocationSize(AllocationHeader const * const header);
 
 	// Get the alignment of the heap, which depends on the largest cache line size.
 	uintptr_t heap_getHeapAlignment();

--- a/Source/DFPSR/implementation/gui/components/TextBox.cpp
+++ b/Source/DFPSR/implementation/gui/components/TextBox.cpp
@@ -245,7 +245,7 @@ BeamLocation TextBox::findBeamLocation(const LVector2D &pixelLocation) {
 	return BeamLocation(rowIndex, this->findBeamLocationInLine(rowIndex, pixelLocation.x));
 }
 
-static int64_t findBeamRow(List<LineIndex> lines, int64_t beamLocation) {
+static int64_t findBeamRow(const List<LineIndex>& lines, int64_t beamLocation) {
 	int64_t result = 0;
 	for (int64_t row = 0; row < lines.length(); row++) {
 		int64_t startIndex = lines[row].lineStartIndex;
@@ -258,7 +258,7 @@ static int64_t findBeamRow(List<LineIndex> lines, int64_t beamLocation) {
 }
 
 // Returns the beam's pixel offset relative to the origin.
-static int64_t getBeamPixelOffset(const ReadableString &text, const RasterFont &font, List<LineIndex> lines, const BeamLocation &beam) {
+static int64_t getBeamPixelOffset(const ReadableString &text, const RasterFont &font, const List<LineIndex>& lines, const BeamLocation &beam) {
 	int64_t result = 0;
 	int64_t lineStartIndex = lines[beam.rowIndex].lineStartIndex;
 	int64_t lineEndIndex = lines[beam.rowIndex].lineEndIndex;

--- a/Source/test/testTools.h
+++ b/Source/test/testTools.h
@@ -107,6 +107,7 @@ void dsrMain(List<String> args) { \
 	stateName = string_combine(U"After expected crash starting with ", PREFIX, U"\n");
 
 #define ASSERT(CONDITION) \
+{ \
 	stateName = string_combine(U"While evaluating condition ", #CONDITION, U"\n"); \
 	if (CONDITION) { \
 		printText(U"*"); \
@@ -119,6 +120,7 @@ void dsrMain(List<String> args) { \
 			U"____________________________________________________________________\n" \
 		); \
 	} \
+}
 
 #define ASSERT_COMP(A, B, OP, OP_NAME) \
 { \

--- a/Source/test/tests/ListTest.cpp
+++ b/Source/test/tests/ListTest.cpp
@@ -1,7 +1,69 @@
 ﻿
 #include "../testTools.h"
 
+static void targetByReference(List<int32_t> &target, int32_t value) {
+	target.push(value);
+}
+
 START_TEST(List)
+	{
+		// Populate
+		List<int32_t> integers;
+		ASSERT_EQUAL(integers.length(), 0);
+		targetByReference(integers, 5);
+		ASSERT_EQUAL(integers.length(), 1);
+		ASSERT_EQUAL(integers[0], 5);
+		targetByReference(integers, 86);
+		ASSERT_EQUAL(integers.length(), 2);
+		ASSERT_EQUAL(integers[0], 5);
+		ASSERT_EQUAL(integers[1], 86);
+		std::function<void(int32_t value)> method = [&integers](int32_t value) {
+			integers.push(value);
+		};
+		method(24);
+		ASSERT_EQUAL(integers.length(), 3);
+		ASSERT_EQUAL(integers[0], 5);
+		ASSERT_EQUAL(integers[1], 86);
+		ASSERT_EQUAL(integers[2], 24);
+		integers.pushConstruct(123);
+		ASSERT_EQUAL(integers.length(), 4);
+		ASSERT_EQUAL(integers[0], 5);
+		ASSERT_EQUAL(integers[1], 86);
+		ASSERT_EQUAL(integers[2], 24);
+		ASSERT_EQUAL(integers[3], 123);
+		// Copy
+		List<int32_t> copied = List<int32_t>(integers);
+		ASSERT_EQUAL(integers.length(), 4);
+		ASSERT_EQUAL(integers[0], 5);
+		ASSERT_EQUAL(integers[1], 86);
+		ASSERT_EQUAL(integers[2], 24);
+		ASSERT_EQUAL(integers[3], 123);
+		ASSERT_EQUAL(copied.length(), 4);
+		ASSERT_EQUAL(copied[0], 5);
+		ASSERT_EQUAL(copied[1], 86);
+		ASSERT_EQUAL(copied[2], 24);
+		ASSERT_EQUAL(copied[3], 123);
+		// Assign
+		List<int32_t> assigned = integers;
+		ASSERT_EQUAL(integers.length(), 4);
+		ASSERT_EQUAL(integers[0], 5);
+		ASSERT_EQUAL(integers[1], 86);
+		ASSERT_EQUAL(integers[2], 24);
+		ASSERT_EQUAL(integers[3], 123);
+		ASSERT_EQUAL(assigned.length(), 4);
+		ASSERT_EQUAL(assigned[0], 5);
+		ASSERT_EQUAL(assigned[1], 86);
+		ASSERT_EQUAL(assigned[2], 24);
+		ASSERT_EQUAL(assigned[3], 123);
+		// Move
+		List<int32_t> moved = std::move(integers);
+		ASSERT_EQUAL(integers.length(), 0);
+		ASSERT_EQUAL(moved.length(), 4);
+		ASSERT_EQUAL(moved[0], 5);
+		ASSERT_EQUAL(moved[1], 86);
+		ASSERT_EQUAL(moved[2], 24);
+		ASSERT_EQUAL(moved[3], 123);
+	}
 	{ // Fixed size elements
 		List<int> myIntegers;
 		ASSERT_EQUAL(myIntegers.length(), 0);
@@ -66,4 +128,5 @@ START_TEST(List)
 		myOtherStrings.clear();
 		ASSERT_EQUAL(myOtherStrings.length(), 0);
 	}
+	// TODO: Test lists of objects that can not be cloned.
 END_TEST


### PR DESCRIPTION
Implemented the used subset of std::vector directly in dsr::List to simplify the dependencies.