### PR TITLE
Doubled the speed of building regression tests

### DIFF
--- a/Source/test/testTools.h
+++ b/Source/test/testTools.h
@@ -1,8 +1,9 @@
 ﻿#ifndef TEST_TOOLS
 #define TEST_TOOLS
 
-// TODO: Make it faster to crawl source by only including what is needed by the test.
-#include "../DFPSR/includeFramework.h"
+#include "../DFPSR/includeEssentials.h"
+#include "../DFPSR/api/algorithmAPI.h"
+#include "../DFPSR/math/FVector.h"
 #include <cstdlib>
 #include <csignal>
 

--- a/Source/test/tests/ArrayTest.cpp
+++ b/Source/test/tests/ArrayTest.cpp
@@ -1,5 +1,6 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/collection/Array.h"
 
 START_TEST(Array)
 	{

--- a/Source/test/tests/BufferTest.cpp
+++ b/Source/test/tests/BufferTest.cpp
@@ -1,5 +1,6 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/api/bufferAPI.h"
 
 START_TEST(Buffer)
 	{

--- a/Source/test/tests/DrawTest.cpp
+++ b/Source/test/tests/DrawTest.cpp
@@ -1,5 +1,7 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/api/imageAPI.h"
+#include "../../DFPSR/api/drawAPI.h"
 
 START_TEST(Draw)
 	// Resources

--- a/Source/test/tests/FieldTest.cpp
+++ b/Source/test/tests/FieldTest.cpp
@@ -1,5 +1,6 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/collection/Field.h"
 
 START_TEST(Field)
 	{

--- a/Source/test/tests/FileTest.cpp
+++ b/Source/test/tests/FileTest.cpp
@@ -1,6 +1,7 @@
 ﻿
 #define NO_IMPLICIT_PATH_SYNTAX
 #include "../testTools.h"
+#include "../../DFPSR/api/fileAPI.h"
 
 START_TEST(File)
 	{ // Combining paths

--- a/Source/test/tests/ImageProcessingTest.cpp
+++ b/Source/test/tests/ImageProcessingTest.cpp
@@ -1,5 +1,7 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/api/imageAPI.h"
+#include "../../DFPSR/api/filterAPI.h"
 #include "../../DFPSR/base/simd.h"
 
 AlignedImageU8 addImages_generate(ImageU8 imageA, ImageU8 imageB) {

--- a/Source/test/tests/ImageTest.cpp
+++ b/Source/test/tests/ImageTest.cpp
@@ -1,5 +1,6 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/api/imageAPI.h"
 
 START_TEST(Image)
 	{ // ImageU8

--- a/Source/test/tests/ListTest.cpp
+++ b/Source/test/tests/ListTest.cpp
@@ -1,5 +1,6 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/collection/List.h"
 
 static void targetByReference(List<int32_t> &target, int32_t value) {
 	target.push(value);

--- a/Source/test/tests/PixelTest.cpp
+++ b/Source/test/tests/PixelTest.cpp
@@ -1,5 +1,6 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/api/imageAPI.h"
 
 START_TEST(Pixel)
 	{ // ImageU8

--- a/Source/test/tests/SafePointerTest.cpp
+++ b/Source/test/tests/SafePointerTest.cpp
@@ -1,5 +1,6 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/base/SafePointer.h"
 
 START_TEST(SafePointer)
 	// Simulate unaligned memory

--- a/Source/test/tests/SimdTest.cpp
+++ b/Source/test/tests/SimdTest.cpp
@@ -1,6 +1,7 @@
 ﻿
 #include "../testTools.h"
 #include "../../DFPSR/base/simd.h"
+#include "../../DFPSR/base/endian.h"
 
 // TODO: Test: allLanesNotEqual, allLanesLesser, allLanesGreater, allLanesLesserOrEqual, allLanesGreaterOrEqual, operand ~, smaller bit shifts.
 // TODO: Test that truncateToU32 saturates to minimum and maximum values.

--- a/Source/test/tests/StringTest.cpp
+++ b/Source/test/tests/StringTest.cpp
@@ -1,9 +1,7 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/api/stringAPI.h"
 
-// TODO: Cannot use casting to parent type at the same time as automatic conversion from const char*
-//       Cover everything using a single dsr::String type?
-//       Use "" operand as only constructor?
 void fooInPlace(dsr::String& target, const dsr::ReadableString& a, const dsr::ReadableString& b) {
 	string_clear(target);
 	string_append(target, U"Foo(");

--- a/Source/test/tests/TextEncodingTest.cpp
+++ b/Source/test/tests/TextEncodingTest.cpp
@@ -1,5 +1,6 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/api/stringAPI.h"
 
 // These tests will fail if the source code document or stored files change their encoding of line breaks.
 

--- a/Source/test/tests/TextureTest.cpp
+++ b/Source/test/tests/TextureTest.cpp
@@ -2,6 +2,7 @@
 #include "../testTools.h"
 #include "../../DFPSR/base/simd.h"
 #include "../../DFPSR/implementation/image/PackOrder.h"
+#include "../../DFPSR/api/textureAPI.h"
 
 #define ASSERT_EQUAL_SIMD(A, B) ASSERT_COMP(A, B, allLanesEqual, "==")
 #define ASSERT_NOTEQUAL_SIMD(A, B) ASSERT_COMP(A, B, !allLanesEqual, "!=")

--- a/Source/test/tests/VectorTest.cpp
+++ b/Source/test/tests/VectorTest.cpp
@@ -1,5 +1,9 @@
 ﻿
 #include "../testTools.h"
+#include "../../DFPSR/math/UVector.h"
+#include "../../DFPSR/math/IVector.h"
+#include "../../DFPSR/math/LVector.h"
+#include "../../DFPSR/math/FVector.h"
 
 START_TEST(Vector)
 	// Comparisons

--- a/Source/tools/builder/code/analyzer.cpp
+++ b/Source/tools/builder/code/analyzer.cpp
@@ -152,7 +152,7 @@ static void tokenize(List<String> &target, ReadableString line) {
 
 #ifdef CACHED_ANALYSIS
 	// Remembering previous results from analyzing the same files.
-	List<Dependency> analysisCache;
+	static List<Dependency> analysisCache;
 #endif
 
 void analyzeFile(Dependency &result, ReadableString absolutePath, Extension extension) {
@@ -211,6 +211,9 @@ void analyzeFile(Dependency &result, ReadableString absolutePath, Extension exte
 			tokens.clear();
 		}
 	});
+	#ifdef CACHED_ANALYSIS
+		analysisCache.push(result);
+	#endif
 }
 
 void analyzeFromFile(ProjectContext &context, ReadableString absolutePath) {


### PR DESCRIPTION
Fixed missing caching of crawl results in Builder and reduced dependencies for tests.