### PR TITLE
Removed a redundant template argument in textureAPI

### DIFF
--- a/Source/DFPSR/api/textureAPI.h
+++ b/Source/DFPSR/api/textureAPI.h
@@ -287,7 +287,7 @@ namespace dsr {
 	// texture_interpolate_color_linear(a, b, 0) = a
 	// texture_interpolate_color_linear(a, b, 128) = floor((a + b) / 2)
 	// texture_interpolate_color_linear(a, b, 256) = b
-	template <typename U32, typename U16>
+	template <typename U32>
 	inline U32 texture_interpolate_color_linear(const U32 &colorA, const U32 &colorB, const U32 &weight) {
 		// Get inverse weights
 		auto weightB = repeatAs16Bits(weight);

--- a/Source/test/tests/TextureTest.cpp
+++ b/Source/test/tests/TextureTest.cpp
@@ -10,7 +10,7 @@
 START_TEST(Texture)
 	{
 		// Linear blending of colors using unsigned integers.
-		U32x4 mixedColor = texture_interpolate_color_linear<U32x4, U16x8>(
+		U32x4 mixedColor = texture_interpolate_color_linear<U32x4>(
 		    packOrder_packBytes(U32x4(255, 175, 253,  95), U32x4(255,  84, 255, 210), U32x4(  0, 253, 172, 100), U32x4(  0, 150, 241,  61)),
 		    packOrder_packBytes(U32x4(  0, 215,  62, 127), U32x4(255, 162, 152,  93), U32x4(255,  71,  62, 200), U32x4(  0, 139, 180, 124)),
 		    U32x4(  0, 128, 256, 256)


### PR DESCRIPTION
Tested the linear color interpolation from an application, but it would not compile when one template argument was unused.