### PR TITLE
Partial integration of Cocoa with Core Graphics

### DIFF
--- a/Source/DFPSR/DFPSR.DsrHead
+++ b/Source/DFPSR/DFPSR.DsrHead
@@ -1,16 +1,11 @@
-﻿# A project header for using the DFPSR library.
+# A project header for using the DFPSR library.
 #   Backends:
 #     * Give the Graphics flag if the application should be able to create a window.
 #     * Give the Sound flag if the application should be able to generate sounds.
 #   Systems:
 #     * Give the Linux flag when compiling on Linux or similar Posix systems having the same dependencies installed.
+#     * Give the MacOS flag when compiling on MacOS.
 #     * Give the Windows flag when compiling on Microsoft Windows.
-#   Features:
-#     * Give the ReuseMemory flag to enable memory recycling using allocator.cpp.
-#       This can cause crashes if you have more than one memory recycler linked,
-#       because you don't want one implementation allocating and another freeing.
-#   Strings use a subset of the C standard for mangling, so \\ is used to write \.
-#     You can also use / and let the file abstraction layer convert it into \ automatically when running on Windows.
 
 if Linux
 	Message "Building for Linux\n"
@@ -25,9 +20,9 @@ end if
 # Standard math library
 Link "m"
 
-# Standard threading library
+# Posix threading library on all platforms for consistent behavior
 Link "pthread"
-
+                                                                                                                                                                                                                                                   
 # Paths are relative to the current script, even if imported somewhere else
 #   so we use .. to leave the Source/DFPSR folder and then go into the windowManagers folder.
 WindowManager = "../windowManagers/NoWindow.cpp"
@@ -39,10 +34,9 @@ if Graphics
 		WindowManager = "../windowManagers/X11Window.cpp"
 	end if
 	if MacOS
-		# TODO: Replace with a native backend.
-		Message "  Using X11\n"
-		Link "X11"
-		WindowManager = "../windowManagers/X11Window.cpp"
+		Message "  Using Cocoa\n"
+		Framework "Cocoa"
+		WindowManager = "../windowManagers/CocoaWindow.mm"
 	end if
 	if Windows
 		Message "  Using Win32\n"

--- a/Source/DFPSR/implementation/gui/InputEvent.h
+++ b/Source/DFPSR/implementation/gui/InputEvent.h
@@ -45,6 +45,12 @@ enum class KeyboardEventType { KeyDown, KeyUp, KeyType };
 // Characters are case insensitive, because DsrKey refers to the physical key.
 //   Use the decoded Unicode value in DsrChar if you want to distinguish between upper and lower case or use special characters.
 // Control, shift and alt combines left and right sides, because sometimes the system does not say if the key is left or right.
+// On MacOS:
+//   * Both command and control buttons are mapped to DsrKey_Control.
+//   * Option and alt is the same DsrKey_Alt button on Macintosh keyboards.
+//   * Function keys F1 to F12 must be mapped to applications and removed from system shortcuts before they are sent to applications.
+//   * F13 becomes DsrKey_Pause.
+//   * F16 becomes DsrKey_Insert.
 enum DsrKey {
 	DsrKey_LeftArrow, DsrKey_RightArrow, DsrKey_UpArrow, DsrKey_DownArrow, DsrKey_PageUp, DsrKey_PageDown,
 	DsrKey_Control, DsrKey_Shift, DsrKey_Alt, DsrKey_Escape, DsrKey_Pause, DsrKey_Space, DsrKey_Tab,
@@ -53,7 +59,6 @@ enum DsrKey {
 	DsrKey_F1, DsrKey_F2, DsrKey_F3, DsrKey_F4, DsrKey_F5, DsrKey_F6, DsrKey_F7, DsrKey_F8, DsrKey_F9, DsrKey_F10, DsrKey_F11, DsrKey_F12,
 	DsrKey_A, DsrKey_B, DsrKey_C, DsrKey_D, DsrKey_E, DsrKey_F, DsrKey_G, DsrKey_H, DsrKey_I, DsrKey_J, DsrKey_K, DsrKey_L, DsrKey_M,
 	DsrKey_N, DsrKey_O, DsrKey_P, DsrKey_Q, DsrKey_R, DsrKey_S, DsrKey_T, DsrKey_U, DsrKey_V, DsrKey_W, DsrKey_X, DsrKey_Y, DsrKey_Z,
-	// TODO: Add any missing essential keys.
 	DsrKey_Unhandled
 };
 

--- a/Source/SDK/cube/main.cpp
+++ b/Source/SDK/cube/main.cpp
@@ -117,8 +117,8 @@ void dsrMain(List<String> args) {
 		window_executeEvents(window);
 
 		// Request buffers after executing the events, to get newly allocated buffers after resize events
-		auto colorBuffer = window_getCanvas(window);
-		auto depthBuffer = window_getDepthBuffer(window);
+		ImageRgbaU8 colorBuffer = window_getCanvas(window);
+		ImageF32 depthBuffer = window_getDepthBuffer(window);
 
 		// Get target size
 		int targetWidth = image_getWidth(colorBuffer);

--- a/Source/SDK/music/build_macos.sh
+++ b/Source/SDK/music/build_macos.sh
@@ -1,6 +1,3 @@
-# Hack to use X11 on MacOS
-export CPATH=/opt/homebrew/include:$CPATH
-export LIBRARY_PATH=/opt/homebrew/lib:$LIBRARY_PATH
 
 # Launch the build system with Music.DsrProj and MacOS selected as the platform.
 echo "Running build_linux.sh $@"

--- a/Source/SDK/terrain/build_macos.sh
+++ b/Source/SDK/terrain/build_macos.sh
@@ -1,6 +1,3 @@
-# Hack to use X11 on MacOS
-export CPATH=/opt/homebrew/include:$CPATH
-export LIBRARY_PATH=/opt/homebrew/lib:$LIBRARY_PATH
 
 # Launch the build system with Terrain.DsrProj and MacOS selected as the platform.
 echo "Running build_linux.sh $@"

--- a/Source/SDK/terrain/main.cpp
+++ b/Source/SDK/terrain/main.cpp
@@ -385,8 +385,8 @@ void dsrMain(List<String> args) {
 		window_executeEvents(window);
 
 		// Request buffers after executing the events, to get newly allocated buffers after resize events
-		auto colorBuffer = window_getCanvas(window);
-		auto depthBuffer = window_getDepthBuffer(window);
+		ImageRgbaU8 colorBuffer = window_getCanvas(window);
+		ImageF32 depthBuffer = window_getDepthBuffer(window);
 
 		// Get target size
 		int targetWidth = image_getWidth(colorBuffer);

--- a/Source/tools/builder/code/analyzer.cpp
+++ b/Source/tools/builder/code/analyzer.cpp
@@ -193,8 +193,6 @@ void analyzeFile(Dependency &result, ReadableString absolutePath, Extension exte
 		}
 	}
 	// Interpret the file's content.
-	bool objective = ((extension == Extension::M) || (extension == Extension::Mm));
-	String includeToken = objective ? U"import" : U"include";
 	String sourceCode = string_loadFromMemory(fileBuffer);
 	String parentFolder = file_getRelativeParentFolder(absolutePath);
 	List<String> tokens;
@@ -211,7 +209,8 @@ void analyzeFile(Dependency &result, ReadableString absolutePath, Extension exte
 		}
 		if (!continuingLine && tokens.length() > 0) {
 			if (tokens.length() >= 3) {
-				if (string_match(tokens[1], includeToken)) {
+				// Because Objective-C++ allow using both include and import syntax, we might as well just look for both in all languages.
+				if (string_match(tokens[1], U"include") || string_match(tokens[1], U"import")) {
 					if (tokens[2][0] == U'\"') {
 						String relativePath = string_unmangleQuote(tokens[2]);
 						String absoluteHeaderPath = file_getTheoreticalAbsolutePath(relativePath, parentFolder, LOCAL_PATH_SYNTAX);

--- a/Source/tools/builder/code/builderTypes.h
+++ b/Source/tools/builder/code/builderTypes.h
@@ -43,10 +43,12 @@ struct Machine {
 
 enum class Extension {
 	Unknown,
-	H,
-	Hpp,
-	C,
-	Cpp
+	H,   // C/C++ header
+	Hpp, // C++ header
+	C,   // C
+	Cpp, // C++
+	M,   // Objective-C
+	Mm   // Objective-C++
 };
 
 enum class ScriptLanguage {

--- a/Source/windowManagers/CocoaWindow.mm
+++ b/Source/windowManagers/CocoaWindow.mm
@@ -1,0 +1,11 @@
+﻿
+#import <Cocoa/Cocoa.h>
+
+#include "../DFPSR/base/Handle.h"
+#include "../DFPSR/implementation/gui/BackendWindow.h"
+#include "../DFPSR/api/stringAPI.h"
+
+dsr::Handle<dsr::BackendWindow> createBackendWindow(const dsr::String& title, int width, int height) {
+	dsr::sendWarning("Tried to create a DsrWindow with Cocoa!\n");
+	return dsr::Handle<dsr::BackendWindow>();
+}

--- a/Source/windowManagers/CocoaWindow.mm
+++ b/Source/windowManagers/CocoaWindow.mm
@@ -1,11 +1,234 @@
 ﻿
 #import <Cocoa/Cocoa.h>
 
-#include "../DFPSR/base/Handle.h"
+#include "../DFPSR/api/imageAPI.h"
+#include "../DFPSR/api/drawAPI.h"
+#include "../DFPSR/api/timeAPI.h"
 #include "../DFPSR/implementation/gui/BackendWindow.h"
-#include "../DFPSR/api/stringAPI.h"
+#include "../DFPSR/base/heap.h"
+#include <climits>
+
+#include "../DFPSR/settings.h"
+
+// Cocoa can only be called from the main thread.
+//   So it is not even possible to have a dedicated background thread for managing the window.
+//   No multi-threading at all can be used for Cocoa.
+
+static const int bufferCount = 2;
+
+static bool applicationInitialized = false;
+static NSApplication *application;
+
+class CocoaWindow : public dsr::BackendWindow {
+private:
+	// Handle to the Cocoa window
+	NSWindow *window = nullptr;
+	// Handle to the Cocoa view
+	//NSView *view = nullptr;
+
+	// Double buffering to allow drawing to a canvas while displaying the previous one
+	// The image which can be drawn to, sharing memory with the Cocoa image
+	dsr::AlignedImageRgbaU8 canvas[bufferCount];
+	// An Cocoa image wrapped around the canvas pixel data
+	//????Image *canvasX[bufferCount] = {};
+	int drawIndex = 0 % bufferCount;
+	int showIndex = 1 % bufferCount;
+
+	// Remembers the dimensions of the window from creation and resize events
+	//   This allow requesting the size of the window at any time
+	int windowWidth = 0, windowHeight = 0;
+
+	// Called before the application fetches events from the input queue
+	//   Closing the window, moving the mouse, pressing a key, et cetera
+	void prefetchEvents() override;
+	/*
+	// Called to change the cursor visibility and returning true on success
+	void applyCursorVisibility();
+	bool setCursorVisibility(bool visible) override;
+
+	// Place the cursor within the window
+	void setCursorPosition(int x, int y) override;
+
+	// Color format
+	dsr::PackOrderIndex packOrderIndex = dsr::PackOrderIndex::RGBA;
+	dsr::PackOrderIndex getColorFormat();
+	*/
+private:
+	// Helper methods specific to calling XLib
+	void updateTitle();
+private:
+	// Canvas methods
+	dsr::AlignedImageRgbaU8 getCanvas() override { return this->canvas[this->drawIndex]; }
+	void resizeCanvas(int width, int height) override;
+	// Window methods
+	void setTitle(const dsr::String &newTitle) override {
+		this->title = newTitle;
+		this->updateTitle();
+	}
+	int windowState = 0; // 0=none, 1=windowed, 2=fullscreen
+public:
+	// Constructors
+	CocoaWindow(const CocoaWindow&) = delete; // Non-copyable because of pointer aliasing.
+	CocoaWindow(const dsr::String& title, int width, int height);
+	int getWidth() const override { return this->windowWidth; };
+	int getHeight() const override { return this->windowHeight; };
+	// Destructor
+	~CocoaWindow();
+	// Full-screen
+	void setFullScreen(bool enabled) override {
+		// TODO: Implement full-screen.
+	};
+	bool isFullScreen() override { return this->windowState == 2; }
+	// Showing the content
+	void showCanvas() override;
+
+	// TODO: Implement clipboard access.
+	//dsr::ReadableString loadFromClipboard(double timeoutInSeconds) override;
+	//void saveToClipboard(const dsr::ReadableString &text, double timeoutInSeconds) override;
+};
+
+void CocoaWindow::updateTitle() {
+	// Encode the title string as null terminated UFT-8.
+	dsr::Buffer utf8_title = dsr::string_saveToMemory(this->title, dsr::CharacterEncoding::BOM_UTF8, dsr::LineEncoding::Lf, false, true);
+	// Create a native string for MacOS.
+	NSString *windowTitle = [NSString stringWithUTF8String:(char *)(dsr::buffer_dangerous_getUnsafeData(utf8_title))];
+	// Set the window title.
+	[window setTitle:windowTitle];
+}
+
+CocoaWindow::CocoaWindow(const dsr::String& title, int width, int height) {
+	if (!applicationInitialized) {
+		application = [NSApplication sharedApplication];
+		[application setActivationPolicy:NSApplicationActivationPolicyRegular];
+		[application setPresentationOptions:NSApplicationPresentationDefault];
+		[application activateIgnoringOtherApps:YES];
+		applicationInitialized = true;
+	}
+	bool fullScreen = false;
+	if (width < 1 || height < 1) {
+		fullScreen = true;
+		width = 400;
+		height = 300;
+	}
+
+	NSRect region = NSMakeRect(0, 0, width, height);
+	// Create a window
+	@autoreleasepool {
+		this->window = [[NSWindow alloc]
+		  initWithContentRect:region
+		  styleMask: (
+			  NSWindowStyleMaskTitled
+			| NSWindowStyleMaskClosable
+			| NSWindowStyleMaskMiniaturizable
+			| NSWindowStyleMaskResizable
+		  )
+		  backing: NSBackingStoreBuffered
+		  defer: NO];
+	}
+
+	// Set the title
+	this->setTitle(title);
+	// Show the window.
+	[window center];
+	[window makeKeyAndOrderFront:nil];
+	[window makeFirstResponder:nil];
+	if (![window isKeyWindow]) {
+		// TODO: Why does the window never become key despite being visible and active?
+		dsr::sendWarning(U"Failed to make the Cocoa window key!\n");
+	}
+}
+
+// Also locked, but cannot change the name when overriding
+void CocoaWindow::prefetchEvents() {
+	@autoreleasepool {
+		// Process events
+		while (true) {
+			NSEvent *event = [application nextEventMatchingMask:NSEventMaskAny untilDate:nil inMode:NSDefaultRunLoopMode dequeue:YES];
+			if (event == nullptr) break;
+			if ([event type] == NSEventTypeLeftMouseDown
+			 || [event type] == NSEventTypeLeftMouseDragged
+			 || [event type] == NSEventTypeLeftMouseUp
+			 || [event type] == NSEventTypeRightMouseDown
+			 || [event type] == NSEventTypeRightMouseDragged
+			 || [event type] == NSEventTypeRightMouseUp
+			 || [event type] == NSEventTypeOtherMouseDown
+			 || [event type] == NSEventTypeOtherMouseDragged
+			 || [event type] == NSEventTypeOtherMouseUp
+			 || [event type] == NSEventTypeMouseMoved
+			 || [event type] == NSEventTypeMouseEntered
+			 || [event type] == NSEventTypeMouseExited
+			 || [event type] == NSEventTypeScrollWheel) {
+				NSView *view = [window contentView];
+				CGFloat canvasHeight = NSHeight(view.bounds);
+				NSPoint point = [view convertPoint:[event locationInWindow] fromView:nil];
+				// This nasty hack combines an old mouse event with a canvas size that may have changed since the mouse event was created.
+				// TODO: Find a way to get the canvas height from when the mouse event was actually created, so that lagging while resizing a window can not place click events at the wrong coordiates.
+				dsr::IVector2D mousePosition = dsr::IVector2D(int32_t(point.x), int32_t(canvasHeight - point.y));
+				if ([event type] == NSEventTypeLeftMouseDown) {
+					dsr::printText(U"LeftMouseDown at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeLeftMouseDragged) {
+					dsr::printText(U"LeftMouseDragged at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeLeftMouseUp) {
+					dsr::printText(U"LeftMouseUp at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeRightMouseDown) {
+					dsr::printText(U"RightMouseDown at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeRightMouseDragged) {
+					dsr::printText(U"RightMouseDragged at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeRightMouseUp) {
+					dsr::printText(U"RightMouseUp at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeOtherMouseDown) {
+					dsr::printText(U"OtherMouseDown at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeOtherMouseDragged) {
+					dsr::printText(U"OtherMouseDragged at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeOtherMouseUp) {
+					dsr::printText(U"OtherMouseUp at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeMouseMoved) {
+					dsr::printText(U"MouseMoved at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeMouseEntered) {
+					dsr::printText(U"MouseEntered at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeMouseExited) {
+					dsr::printText(U"MouseExited at ", mousePosition, U"\n");
+				} else if ([event type] == NSEventTypeScrollWheel) {
+					dsr::printText(U"ScrollWheel at ", mousePosition, U"\n");
+				}
+				[this->window makeKeyAndOrderFront:nil];
+			} else if ([event type] == NSEventTypeKeyDown
+			        || [event type] == NSEventTypeKeyUp
+			        || [event type] == NSEventTypeFlagsChanged) {
+				// TODO: Make sure that the window catches keyboard events instead of corrupting terminal input.
+				if ([event type] == NSEventTypeKeyDown) {
+					if (!(event.isARepeat)) {
+						dsr::printText(U"KeyDown\n");
+					}
+					dsr::printText(U"KeyType\n");
+				} else if ([event type] == NSEventTypeKeyUp) {
+					dsr::printText(U"KeyUp\n");
+				} else if ([event type] == NSEventTypeFlagsChanged) {
+					dsr::printText(U"FlagsChanged\n");
+				}
+				dsr::printText(U"keyCode = ", event.keyCode, U"\n");
+				
+			}
+			[application sendEvent:event];
+			[application updateWindows];
+		}
+	}
+}
+
+// Locked because it overrides
+void CocoaWindow::resizeCanvas(int width, int height) {
+	// TODO: Resize.
+}
+
+CocoaWindow::~CocoaWindow() {
+	[this->window close];
+	window = nullptr;
+}
+
+void CocoaWindow::showCanvas() {
+	// TODO: Implement
+}
 
 dsr::Handle<dsr::BackendWindow> createBackendWindow(const dsr::String& title, int width, int height) {
-	dsr::sendWarning("Tried to create a DsrWindow with Cocoa!\n");
-	return dsr::Handle<dsr::BackendWindow>();
+	return dsr::handle_create<CocoaWindow>(title, width, height);
 }

--- a/Source/windowManagers/CocoaWindow.mm
+++ b/Source/windowManagers/CocoaWindow.mm
@@ -136,6 +136,140 @@ CocoaWindow::CocoaWindow(const dsr::String& title, int width, int height) {
 	[window makeFirstResponder:nil];
 }
 
+static dsr::DsrKey getDsrKey(uint16_t keyCode) {
+	dsr::DsrKey result = dsr::DsrKey_Unhandled;
+	if (keyCode == 53) {
+		result = dsr::DsrKey_Escape;
+	} else if (keyCode == 122) {
+		result = dsr::DsrKey_F1;
+	} else if (keyCode == 120) {
+		result = dsr::DsrKey_F2;
+	} else if (keyCode == 99) {
+		result = dsr::DsrKey_F3;
+	} else if (keyCode == 118) {
+		result = dsr::DsrKey_F4;
+	} else if (keyCode == 96) {
+		result = dsr::DsrKey_F5;
+	} else if (keyCode == 97) {
+		result = dsr::DsrKey_F6;
+	} else if (keyCode == 98) {
+		result = dsr::DsrKey_F7;
+	} else if (keyCode == 100) {
+		result = dsr::DsrKey_F8;
+	} else if (keyCode == 101) {
+		result = dsr::DsrKey_F9;
+	} else if (keyCode == 109) {
+		result = dsr::DsrKey_F10;
+	} else if (keyCode == 103) {
+		result = dsr::DsrKey_F11;
+	} else if (keyCode == 111) {
+		result = dsr::DsrKey_F12;
+	} else if (keyCode == 105) { // F13 replaces the pause key that does not even have a keycode on MacOS.
+		result = dsr::DsrKey_Pause;
+	} else if (keyCode == 49) {
+		result = dsr::DsrKey_Space;
+	} else if (keyCode == 48) {
+		result = dsr::DsrKey_Tab;
+	} else if (keyCode == 36) {
+		result = dsr::DsrKey_Return;
+	} else if (keyCode == 51) {
+		result = dsr::DsrKey_BackSpace;
+	} else if (keyCode == 117) {
+		result = dsr::DsrKey_Delete;
+	} else if (keyCode == 123) {
+		result = dsr::DsrKey_LeftArrow;
+	} else if (keyCode == 124) {
+		result = dsr::DsrKey_RightArrow;
+	} else if (keyCode == 126) {
+		result = dsr::DsrKey_UpArrow;
+	} else if (keyCode == 125) {
+		result = dsr::DsrKey_DownArrow;
+	} else if (keyCode == 29) {
+		result = dsr::DsrKey_0;
+	} else if (keyCode == 18) {
+		result = dsr::DsrKey_1;
+	} else if (keyCode == 19) {
+		result = dsr::DsrKey_2;
+	} else if (keyCode == 20) {
+		result = dsr::DsrKey_3;
+	} else if (keyCode == 21) {
+		result = dsr::DsrKey_4;
+	} else if (keyCode == 23) {
+		result = dsr::DsrKey_5;
+	} else if (keyCode == 22) {
+		result = dsr::DsrKey_6;
+	} else if (keyCode == 26) {
+		result = dsr::DsrKey_7;
+	} else if (keyCode == 28) {
+		result = dsr::DsrKey_8;
+	} else if (keyCode == 25) {
+		result = dsr::DsrKey_9;
+	} else if (keyCode == 0) {
+		result = dsr::DsrKey_A;
+	} else if (keyCode == 11) {
+		result = dsr::DsrKey_B;
+	} else if (keyCode == 8) {
+		result = dsr::DsrKey_C;
+	} else if (keyCode == 2) {
+		result = dsr::DsrKey_D;
+	} else if (keyCode == 14) {
+		result = dsr::DsrKey_E;
+	} else if (keyCode == 3) {
+		result = dsr::DsrKey_F;
+	} else if (keyCode == 5) {
+		result = dsr::DsrKey_G;
+	} else if (keyCode == 4) {
+		result = dsr::DsrKey_H;
+	} else if (keyCode == 34) {
+		result = dsr::DsrKey_I;
+	} else if (keyCode == 38) {
+		result = dsr::DsrKey_J;
+	} else if (keyCode == 40) {
+		result = dsr::DsrKey_K;
+	} else if (keyCode == 37) {
+		result = dsr::DsrKey_L;
+	} else if (keyCode == 46) {
+		result = dsr::DsrKey_M;
+	} else if (keyCode == 45) {
+		result = dsr::DsrKey_N;
+	} else if (keyCode == 31) {
+		result = dsr::DsrKey_O;
+	} else if (keyCode == 35) {
+		result = dsr::DsrKey_P;
+	} else if (keyCode == 12) {
+		result = dsr::DsrKey_Q;
+	} else if (keyCode == 15) {
+		result = dsr::DsrKey_R;
+	} else if (keyCode == 1) {
+		result = dsr::DsrKey_S;
+	} else if (keyCode == 17) {
+		result = dsr::DsrKey_T;
+	} else if (keyCode == 32) {
+		result = dsr::DsrKey_U;
+	} else if (keyCode == 9) {
+		result = dsr::DsrKey_V;
+	} else if (keyCode == 13) {
+		result = dsr::DsrKey_W;
+	} else if (keyCode == 7) {
+		result = dsr::DsrKey_X;
+	} else if (keyCode == 16) {
+		result = dsr::DsrKey_Y;
+	} else if (keyCode == 6) {
+		result = dsr::DsrKey_Z;
+	} else if (keyCode == 114 || keyCode == 106) { // Insert on PC keyboard or F16 on Mac Keyboard.
+		result = dsr::DsrKey_Insert;
+	} else if (keyCode == 115) {
+		result = dsr::DsrKey_Home;
+	} else if (keyCode == 119) {
+		result = dsr::DsrKey_End;
+	} else if (keyCode == 116) {
+		result = dsr::DsrKey_PageUp;
+	} else if (keyCode == 121) {
+		result = dsr::DsrKey_PageDown;
+	}
+	return result;
+}
+
 // Also locked, but cannot change the name when overriding
 void CocoaWindow::prefetchEvents() {
 	@autoreleasepool {
@@ -164,43 +298,64 @@ void CocoaWindow::prefetchEvents() {
 				dsr::IVector2D mousePosition = dsr::IVector2D(int32_t(point.x), int32_t(canvasHeight - point.y));
 				if ([event type] == NSEventTypeLeftMouseDown) {
 					dsr::printText(U"LeftMouseDown at ", mousePosition, U"\n");
+					this->queueInputEvent(new dsr::MouseEvent(dsr::MouseEventType::MouseDown, dsr::MouseKeyEnum::Left, mousePosition));
 				} else if ([event type] == NSEventTypeLeftMouseDragged) {
 					dsr::printText(U"LeftMouseDragged at ", mousePosition, U"\n");
+					this->queueInputEvent(new dsr::MouseEvent(dsr::MouseEventType::MouseMove, dsr::MouseKeyEnum::NoKey, mousePosition));
 				} else if ([event type] == NSEventTypeLeftMouseUp) {
 					dsr::printText(U"LeftMouseUp at ", mousePosition, U"\n");
+					this->queueInputEvent(new dsr::MouseEvent(dsr::MouseEventType::MouseUp, dsr::MouseKeyEnum::Left, mousePosition));
 				} else if ([event type] == NSEventTypeRightMouseDown) {
 					dsr::printText(U"RightMouseDown at ", mousePosition, U"\n");
 				} else if ([event type] == NSEventTypeRightMouseDragged) {
 					dsr::printText(U"RightMouseDragged at ", mousePosition, U"\n");
+					this->queueInputEvent(new dsr::MouseEvent(dsr::MouseEventType::MouseMove, dsr::MouseKeyEnum::NoKey, mousePosition));
 				} else if ([event type] == NSEventTypeRightMouseUp) {
 					dsr::printText(U"RightMouseUp at ", mousePosition, U"\n");
 				} else if ([event type] == NSEventTypeOtherMouseDown) {
 					dsr::printText(U"OtherMouseDown at ", mousePosition, U"\n");
 				} else if ([event type] == NSEventTypeOtherMouseDragged) {
 					dsr::printText(U"OtherMouseDragged at ", mousePosition, U"\n");
+					this->queueInputEvent(new dsr::MouseEvent(dsr::MouseEventType::MouseMove, dsr::MouseKeyEnum::NoKey, mousePosition));
 				} else if ([event type] == NSEventTypeOtherMouseUp) {
 					dsr::printText(U"OtherMouseUp at ", mousePosition, U"\n");
 				} else if ([event type] == NSEventTypeMouseMoved) {
 					dsr::printText(U"MouseMoved at ", mousePosition, U"\n");
-				} else if ([event type] == NSEventTypeMouseEntered) {
-					dsr::printText(U"MouseEntered at ", mousePosition, U"\n");
-				} else if ([event type] == NSEventTypeMouseExited) {
-					dsr::printText(U"MouseExited at ", mousePosition, U"\n");
+					this->queueInputEvent(new dsr::MouseEvent(dsr::MouseEventType::MouseMove, dsr::MouseKeyEnum::NoKey, mousePosition));
+				//} else if ([event type] == NSEventTypeMouseEntered) {
+				//	dsr::printText(U"MouseEntered at ", mousePosition, U"\n");
+				//} else if ([event type] == NSEventTypeMouseExited) {
+				//	dsr::printText(U"MouseExited at ", mousePosition, U"\n");
 				} else if ([event type] == NSEventTypeScrollWheel) {
 					dsr::printText(U"ScrollWheel at ", mousePosition, U"\n");
+					// TODO: Which direction is considered up/down on MacOS when scroll wheels are inverted relative to PC?
+					if (event.scrollingDeltaY > 0.0) {
+						this->queueInputEvent(new dsr::MouseEvent(dsr::MouseEventType::Scroll, dsr::MouseKeyEnum::ScrollUp, mousePosition));
+					}
+					if (event.scrollingDeltaY < 0.0) {
+						this->queueInputEvent(new dsr::MouseEvent(dsr::MouseEventType::Scroll, dsr::MouseKeyEnum::ScrollDown, mousePosition));
+					}
 				}
 				[this->window makeKeyAndOrderFront:nil];
 			} else if ([event type] == NSEventTypeKeyDown
 			        || [event type] == NSEventTypeKeyUp
 			        || [event type] == NSEventTypeFlagsChanged) {
+				dsr::DsrKey code = getDsrKey(event.keyCode);
 				// TODO: Make sure that the window catches keyboard events instead of corrupting terminal input.
 				if ([event type] == NSEventTypeKeyDown) {
 					if (!(event.isARepeat)) {
-						dsr::printText(U"KeyDown: keyCode = ", event.keyCode, U"\n");
+						dsr::printText(U"KeyDown: keyCode ", event.keyCode, U" -> ", getName(code), U"\n");
+						// TODO: Get the character code.
+						this->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyDown, U'0', code));
 					}
-					dsr::printText(U"KeyType\n");
+					dsr::printText(U"KeyType: keyCode ", event.keyCode, U" -> ", getName(code), U"\n");
+					// TODO: Get the character code.
+					this->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyType, U'0', code));
 				} else if ([event type] == NSEventTypeKeyUp) {
-					dsr::printText(U"KeyUp: keyCode = ", event.keyCode, U"\n");
+					dsr::printText(U"KeyUp: keyCode ", event.keyCode, U" -> ", getName(code), U"\n");
+					// TODO: Get the character code.
+					this->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyUp, U'0', code));
+					
 				} else if ([event type] == NSEventTypeFlagsChanged) {
 					dsr::printText(U"FlagsChanged\n");
 					NSEventModifierFlags newModifierFlags = [event modifierFlags];
@@ -209,18 +364,24 @@ void CocoaWindow::prefetchEvents() {
 					bool newAltOption = (newModifierFlags & NSEventModifierFlagOption) != 0u;
 					if (newControlCommand && !pressedControlCommand) {
 						dsr::printText(U"KeyDown: Control\n");
+						this->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyDown, U'0', dsr::DsrKey_Control));
 					} else if (!newControlCommand && pressedControlCommand) {
 						dsr::printText(U"KeyUp: Control\n");
+						this->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyUp, U'0', dsr::DsrKey_Control));
 					}
 					if (newShift && !pressedShift) {
 						dsr::printText(U"KeyDown: Shift\n");
+						this->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyDown, U'0', dsr::DsrKey_Shift));
 					} else if (!newShift && pressedShift) {
 						dsr::printText(U"KeyUp: Shift\n");
+						this->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyUp, U'0', dsr::DsrKey_Shift));
 					}
 					if (newAltOption && !pressedAltOption) {
 						dsr::printText(U"KeyDown: Alt\n");
+						this->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyDown, U'0', dsr::DsrKey_Alt));
 					} else if (!newAltOption && pressedAltOption) {
 						dsr::printText(U"KeyUp: Alt\n");
+						this->queueInputEvent(new dsr::KeyboardEvent(dsr::KeyboardEventType::KeyUp, U'0', dsr::DsrKey_Alt));
 					}
 					pressedControlCommand = newControlCommand;
 					pressedShift = newShift;

--- a/Source/windowManagers/X11Window.cpp
+++ b/Source/windowManagers/X11Window.cpp
@@ -113,7 +113,7 @@ public:
 	dsr::String textToClipboard;
 	void listContentInClipboard();
 	void initializeClipboard();
-	void terminateClipboard();		
+	void terminateClipboard();
 	dsr::ReadableString loadFromClipboard(double timeoutInSeconds) override;
 	void saveToClipboard(const dsr::ReadableString &text, double timeoutInSeconds) override;
 };


### PR DESCRIPTION
Lots of features are missing and it has known bugs that will take a while to fix, so the MacOS integration is at an early alpha stage. Getting this into the master branch as skeleton code will at least allow fixing the problems in multiple small pull requests instead of snowballing into a huge incomprehensible pull request.

Known bugs:
* The Cocoa window lacks features such as typing text, accessing the clipboard, hiding the cursor, moving the cursor, and toggling fullscreen.
* Mouse coordinates are corrupted becomming negative relative to the upper left corner, so one might need to filter away out of bound mouse move events.
* Uploading the Canvas to Cocoa does not wait for synchronization due to how Objective-C does not wait for anything, so one may sometimes see polygons while they are still being rendered from having more than one unprocessed order to switch which buffer is visible in the swap chain.
* Memory is leaking slowly, which might be an old bug.
* Closing an application with Core Audio may get a crash from trying to use a mutex after it is freed, because the sound backend uses a temporary hack.