### PR TITLE
Fixed memory leak from std::function

### DIFF
--- a/Source/DFPSR/base/threading.h
+++ b/Source/DFPSR/base/threading.h
@@ -33,10 +33,15 @@ namespace dsr {
 // Get the number of threads available.
 int getThreadCount();
 
+// Calls the same job function with indices 0 to jobIndex - 1.
+//   This removes the need for capturing the same data over and over again when each task is identical with a different index.
+void threadedWorkByIndex(std::function<void(void *context, int jobIndex)> job, void *context, int jobCount, int maxThreadCount = 0);
+
 // Executes every function in the array of jobs from jobs[0] to jobs[jobCount - 1].
 //   The maxThreadCount argument is the maximum number of threads to use when enough threads are available.
 //     Letting maxThreadCount be 0 removes the limit and uses as many threads as possible, limited only by getThreadCount() - 1 and jobCount.
 //     Letting maxThreadCount be 1 forces single-threaded execution on the calling thread.
+//   Useful when each job to execute is different.
 void threadedWorkFromArray(SafePointer<std::function<void()>> jobs, int jobCount, int maxThreadCount = 0);
 void threadedWorkFromArray(std::function<void()>* jobs, int jobCount, int maxThreadCount = 0);
 

--- a/Source/DFPSR/base/virtualStack.h
+++ b/Source/DFPSR/base/virtualStack.h
@@ -68,6 +68,21 @@ namespace dsr {
 			virtualStack_pop();
 		}
 	};
+
+	template <typename T>
+	class DestructibleVirtualStackAllocation : public SafePointer<T> {
+	public:
+		uint64_t elementCount;
+		DestructibleVirtualStackAllocation(uint64_t elementCount, const char *name = "Nameless virtual stack allocation", uintptr_t alignmentAndMask = ~uintptr_t(0u))
+		: SafePointer<T>(virtualStack_push<T>(elementCount, name, alignmentAndMask)), elementCount(elementCount) {}
+		~DestructibleVirtualStackAllocation() {
+			// Call destructors.
+			for (uint64_t e = 0; e < elementCount; e++) {
+				(*this)[e].~T();
+			}
+			virtualStack_pop();
+		}
+	};
 }
 
 #endif


### PR DESCRIPTION
std::function is supposed to only heap allocate when getting lots of data to capture, but some std::function implementations will always heap allocate, which causes memory leaks when a heap allocation was not expected by the program. Patched it up by creating a destructible stack allocation that automatically calls destructors, but having hidden heap allocations made outside of the memory allocation system is not good, so a custom lambda type is still needed. Then calls to new and delete can be banned using a setting when looking for memory leaks.

Also created a new method for running threaded work using a single function that is given a new index for each task to perform.