### PR TITLE
Fixed mouse events on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,13 @@ If you are not redistributing the source code, then you do not have to tell anyo
 Theme, GUI, font and sound APIs are still under active development and may have significant changes before a stable version 1.0 is ready, because some code is just a primitive placeholder until the advanced implementation can replace it, and one must try to actually use the library before usability problems become obvious. Buffer, file, image, draw, filter, string and time APIs are however already quite version stable. You can choose to stick with a specific version for each new project, keep updated with the latest changes, or wait for stable version 1.0.
 
 ## How you can help
-* Port to Macintosh or Wayland using the same principles of minimal dependency.
 * Test this beta version and give feedback on the design before version 1.0 is released.
 * Create different types of game engines with open-source tools.
 
 ## Supported CPU hardware:
-* **Intel/AMD** using **SSE2** intrinsics and optional extensions.
+* **Intel/AMD** using **SSE2**, **AVX** and **AVX2** intrinsics and optional extensions.
 * **ARM** using **NEON** intrinsics.
-* Unknown CPU architectures, without SIMD vectorization as a fallback solution.
+* Unknown CPU architectures, by running the same vector operations without SIMD hardware acceleration. This is still faster than naive loops with one iteration per element, because multiple scalar operations in parallel are better at filling the processor's execution window.
 
 ## Platforms:
 * **Linux**, tested on Mint, Mate, Manjaro, Ubuntu, RaspberryPi OS, Raspbian (Buster or later).
@@ -78,7 +77,7 @@ Currently supporting X11 and Wayland is planned for future versions.
 * **Microsoft Windows**, but slower than on Linux because Windows has lots of background processes and slower threading and memory management.
 
 ## Partial support for:
-* MacOS has software rendering and a CoreAudio sound backend working, but still needs to replace X11 with a native port.
+* MacOS still has features missing in the Cocoa integration, but will soon be officially supported.
 
 ## Might also work on:
 * BSD and Solaris have code targeting the platforms in fileAPI.cpp for getting the application folder, but there are likely some applications missing for running the build script.

--- a/Source/SDK/integrationTest/tests/inputTest.cpp
+++ b/Source/SDK/integrationTest/tests/inputTest.cpp
@@ -1,4 +1,6 @@
 
+// TODO: Include settings to adapt instructions for specific operating systems, such as control click and command click on MacOS and F keys for insert and pause.
+
 #include "inputTest.h"
 
 using namespace dsr;
@@ -121,11 +123,11 @@ void inputTests_populate(List<Test> &target, int buttonCount, bool relative, boo
 				if (TASK_IS(0)) {
 					font_printLine(canvas, font_getDefault(), U"Scroll in the direction used to reach the top of a document by moving content down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				} else if (TASK_IS(1)) {
-					font_printLine(canvas, font_getDefault(), U"Click when you are down scrolling up.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+					font_printLine(canvas, font_getDefault(), U"Click when you are done scrolling up.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				} else if (TASK_IS(2)) {
 					font_printLine(canvas, font_getDefault(), U"Scroll in the direction used to reach the bottom of a document by moving content up.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				} else if (TASK_IS(3)) {
-					font_printLine(canvas, font_getDefault(), U"Click when you are down scrolling down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
+					font_printLine(canvas, font_getDefault(), U"Click when you are done scrolling down.", IVector2D(40, 40), ColorRgbaI32(0, 0, 0, 255));
 				}
 			}
 		,


### PR DESCRIPTION
All mouse and keyboard input can now pass the integration test on a Macintosh keyboard, with or without using extra mouse buttons. Control click to right click with the left/only button. Command click to middle click with the left/only button.

If one presses two left mouse buttons at the same time while releasing control during the press, the first release raises the right button, because there is no identity for which left mouse button was pressed.