### PR TITLE
Fixed more missing features for Cocoa

### DIFF
--- a/Source/windowManagers/CocoaWindow.mm
+++ b/Source/windowManagers/CocoaWindow.mm
@@ -9,7 +9,7 @@
 //       On MacOS, maximizing is only supposed to enter a partial fullscreen mode where you can hover at the top to access the menu and window decorations.
 //   * Minimizing the window
 //     It just bounces back instantly.
-//   * Setting cursor position and visibility.
+//   * Setting cursor position.
 //     Not yet implemented.
 //   * Turn off the annoying system sounds that are triggered by every key press.
 
@@ -72,14 +72,12 @@ private:
 	// Called before the application fetches events from the input queue
 	//   Closing the window, moving the mouse, pressing a key, et cetera
 	void prefetchEvents() override;
-	/*
+
 	// Called to change the cursor visibility and returning true on success
-	void applyCursorVisibility();
 	bool setCursorVisibility(bool visible) override;
 
 	// Place the cursor within the window
-	void setCursorPosition(int x, int y) override;
-	*/
+	//void setCursorPosition(int x, int y) override;
 private:
 	// Helper methods specific to calling XLib
 	void updateTitle();
@@ -146,6 +144,15 @@ void CocoaWindow::saveToClipboard(const dsr::ReadableString &text, double timeou
 	NSPasteboard *clipboard = [NSPasteboard generalPasteboard];
 	[clipboard clearContents];
 	[clipboard setString:savedText forType:NSPasteboardTypeString];
+}
+
+bool CocoaWindow::setCursorVisibility(bool visible) {
+	if (visible) {
+		[NSCursor unhide];
+	} else {
+		[NSCursor hide];
+	}
+	return true;
 }
 
 void CocoaWindow::setDecorations(bool decorated) {

--- a/Source/windowManagers/CocoaWindow.mm
+++ b/Source/windowManagers/CocoaWindow.mm
@@ -5,13 +5,13 @@
 //   * Toggling full-screen
 //     The menu and shortcuts are not hidden when entering fullscreen using the setFullScreen method.
 //       Real full screen should not make menus appear when hovering.
+//       The window is also partially outside of the screen by being pushed away by the shortcuts.
 //     Pressing the maximize button enters a full screen mode where you can not exit fullscreen without forcefully terminating the application.
 //       On MacOS, maximizing is only supposed to enter a partial fullscreen mode where you can hover at the top to access the menu and window decorations.
 //   * Minimizing the window
 //     It just bounces back instantly.
 //   * Setting cursor position.
 //     Not yet implemented.
-//   * Turn off the annoying system sounds that are triggered by every key press.
 
 // Potential optimizations:
 // * Double buffering is disabled for safety by assigining bufferCount to 1 instead of 2 and copying presented pixel data to delayedCanvas.
@@ -474,6 +474,7 @@ void CocoaWindow::prefetchEvents() {
 					}
 				}
 				[this->window makeKeyAndOrderFront:nil];
+				[application sendEvent:event];
 			} else if ([event type] == NSEventTypeKeyDown
 			        || [event type] == NSEventTypeKeyUp
 			        || [event type] == NSEventTypeFlagsChanged) {
@@ -525,8 +526,11 @@ void CocoaWindow::prefetchEvents() {
 					this->pressedShift = newShift;
 					this->pressedAltOption = newAltOption;
 				}
+				// TODO: Make sure that this does not break anything important.
+				// Supressing beeps by not forwarding key events to the system.
+			} else {
+				[application sendEvent:event];
 			}
-			[application sendEvent:event];
 			[application updateWindows];
 		}
 		// Handle changes to the window.


### PR DESCRIPTION
The cursor can now be hidden.

No more annoying beep sounds while holding down keys. Hopefully this will not break something important when key events are not passed on.

Almost got fullscreen working, so now it will at least change the window size instead of just toggling decorations. Maybe someone knows hot to get **real fullscreen** for games working. All examples I could find on the internet were examples of how to maximize the window, which is confusingly called fullscreen on MacOS.