### PR TITLE
Implemented parsing of scientific notation in string_toDouble

### DIFF
--- a/Source/DFPSR/api/stringAPI.cpp
+++ b/Source/DFPSR/api/stringAPI.cpp
@@ -31,6 +31,7 @@
 #include <thread>
 #include <mutex>
 #include <stdexcept>
+#include <cmath>
 #include "stringAPI.h"
 #include "../api/fileAPI.h"
 #include "../settings.h"
@@ -1019,6 +1020,11 @@ double dsr::string_toDouble(const ReadableString& source) {
 			}
 		} else if (c == ',' || c == '.') {
 			reachedDecimal = true;
+		} else if (c == 'e' || c == 'E') {
+			// Apply the exponent after 'e'.
+			result *= std::pow(10.0, string_toInteger(string_after(source, i)));
+			// Skip remaining characters.
+			i = source.view.length;
 		}
 	}
 	if (negated) {

--- a/Source/test/testTools.h
+++ b/Source/test/testTools.h
@@ -32,6 +32,9 @@ static thread_local String ExpectedErrorPrefix;
 inline bool OP_NEAR(float a, float b) {
 	return a > b - 0.0001f && a < b + 0.0001f;
 }
+inline bool OP_NEAR(double a, double b) {
+	return a > b - 0.0000001 && a < b + 0.0000001;
+}
 inline bool OP_NEAR(const FVector2D& a, const FVector2D& b) {
 	return OP_NEAR(a.x, b.x) && OP_NEAR(a.y, b.y);
 }

--- a/Source/test/tests/StringTest.cpp
+++ b/Source/test/tests/StringTest.cpp
@@ -273,8 +273,15 @@ START_TEST(String)
 	ASSERT_EQUAL(string_toInteger(U"1000000"), 1000000);
 	ASSERT_EQUAL(string_toInteger(U"-1000000"), -1000000);
 	ASSERT_EQUAL(string_toInteger(U"123"), 123);
-	ASSERT_EQUAL(string_toDouble(U"123"), 123.0);
-	ASSERT_EQUAL(string_toDouble(U"123.456"), 123.456);
+	ASSERT_NEAR(string_toDouble(U"123"), 123.0);
+	ASSERT_NEAR(string_toDouble(U"123.456"), 123.456);
+	ASSERT_NEAR(string_toDouble(U"123.456e-3"), 0.123456);
+	ASSERT_NEAR(string_toDouble(U"123.456e-2"), 1.23456);
+	ASSERT_NEAR(string_toDouble(U"123.456e-1"), 12.3456);
+	ASSERT_NEAR(string_toDouble(U"123.456e0"), 123.456);
+	ASSERT_NEAR(string_toDouble(U"123.456e1"), 1234.56);
+	ASSERT_NEAR(string_toDouble(U"123.456e2"), 12345.6);
+	ASSERT_NEAR(string_toDouble(U"123.456e3"), 123456.0);
 	{ // Assigning strings using reference counting
 		String a = U"Some text";
 		ASSERT_EQUAL(string_getBufferUseCount(a), 1);


### PR DESCRIPTION
This makes it easier to import 3D models, even when they randomly change the format into an exponent instead of just rounding to zero.