### PR TITLE
More list tests

### DIFF
--- a/Source/DFPSR/collection/List.h
+++ b/Source/DFPSR/collection/List.h
@@ -230,6 +230,8 @@ public:
 	}
 	// Side-effect: Pushes a new element constructed using the given arguments.
 	//   Warning! Reallocation may invalidate old pointers and references to elements in the replaced buffer.
+	//   Warning! Do not pass an element in the list as an argument to the constructor,
+	//     because reallocating will move the data from that location before being sent to the constructor.
 	// Post-condition: Returns a reference to the new element in the list.
 	template<typename... ARGS>
 	T& pushConstruct(ARGS&&... args) {
@@ -240,6 +242,8 @@ public:
 	}
 	// Side-effect: Pushes a new element constructed using the given arguments.
 	//   Warning! Reallocation may invalidate old pointers and references to elements in the replaced buffer.
+	//   Warning! Do not pass an element in the list as an argument to the constructor,
+	//     because reallocating will move the data from that location before being sent to the constructor.
 	// Post-condition: Returns an index to the new element in the list.
 	template<typename... ARGS>
 	intptr_t pushConstructGetIndex(ARGS&&... args) {

--- a/Source/test/tests/ListTest.cpp
+++ b/Source/test/tests/ListTest.cpp
@@ -179,6 +179,13 @@ START_TEST(List)
 		ASSERT_EQUAL(objects[0].name, U"Two");
 		ASSERT_EQUAL(objects[1].name, U"One");
 		ASSERT_EQUAL(objects[2].name, U"Three");
+		// Move the whole list.
+		List<Unique> objects2 = std::move(objects);
+		ASSERT_EQUAL(objects.length(), 0);
+		ASSERT_EQUAL(objects2.length(), 3);
+		ASSERT_EQUAL(objects2[0].name, U"Two");
+		ASSERT_EQUAL(objects2[1].name, U"One");
+		ASSERT_EQUAL(objects2[2].name, U"Three");
 	}
 	{
 		// Default movable and copyable types should clone the content recursively when the list is copied.
@@ -222,5 +229,50 @@ START_TEST(List)
 				ASSERT_EQUAL(treeFour.children[0].children[1].children.length(), 0);
 			ASSERT_EQUAL(treeFour.children[1].name, U"C");
 			ASSERT_EQUAL(treeFour.children[1].children.length(), 0);
+		// Move the first tree to a new location.
+		Tree newTree = std::move(treeOne);
+		ASSERT_EQUAL(treeOne.children.length(), 0);
+		ASSERT_EQUAL(newTree.name, U"A1");
+		ASSERT_EQUAL(newTree.children.length(), 2);
+			ASSERT_EQUAL(newTree.children[0].name, U"B");
+			ASSERT_EQUAL(newTree.children[0].children.length(), 2);
+				ASSERT_EQUAL(newTree.children[0].children[0].name, U"D");
+				ASSERT_EQUAL(newTree.children[0].children[0].children.length(), 0);
+				ASSERT_EQUAL(newTree.children[0].children[1].name, U"E");
+				ASSERT_EQUAL(newTree.children[0].children[1].children.length(), 0);
+			ASSERT_EQUAL(newTree.children[1].name, U"C");
+			ASSERT_EQUAL(newTree.children[1].children.length(), 0);
+	}
+	{
+		// Construct and push.
+		Tree tree = Tree(U"A");
+		tree.children.push(Tree(U"B", List<Tree>(Tree(U"D"), Tree(U"E"))));
+		tree.children.push(Tree(U"C"));
+		ASSERT_EQUAL(tree.name, U"A");
+		ASSERT_EQUAL(tree.children.length(), 2);
+			ASSERT_EQUAL(tree.children[0].name, U"B");
+			ASSERT_EQUAL(tree.children[0].children.length(), 2);
+				ASSERT_EQUAL(tree.children[0].children[0].name, U"D");
+				ASSERT_EQUAL(tree.children[0].children[0].children.length(), 0);
+				ASSERT_EQUAL(tree.children[0].children[1].name, U"E");
+				ASSERT_EQUAL(tree.children[0].children[1].children.length(), 0);
+			ASSERT_EQUAL(tree.children[1].name, U"C");
+			ASSERT_EQUAL(tree.children[1].children.length(), 0);
+	}
+	{
+		// Push-construct.
+		Tree tree = Tree(U"A");
+		tree.children.pushConstruct(U"B", List<Tree>(Tree(U"D"), Tree(U"E")));
+		tree.children.pushConstruct(U"C");
+		ASSERT_EQUAL(tree.name, U"A");
+		ASSERT_EQUAL(tree.children.length(), 2);
+			ASSERT_EQUAL(tree.children[0].name, U"B");
+			ASSERT_EQUAL(tree.children[0].children.length(), 2);
+				ASSERT_EQUAL(tree.children[0].children[0].name, U"D");
+				ASSERT_EQUAL(tree.children[0].children[0].children.length(), 0);
+				ASSERT_EQUAL(tree.children[0].children[1].name, U"E");
+				ASSERT_EQUAL(tree.children[0].children[1].children.length(), 0);
+			ASSERT_EQUAL(tree.children[1].name, U"C");
+			ASSERT_EQUAL(tree.children[1].children.length(), 0);
 	}
 END_TEST


### PR DESCRIPTION
Noted that the new implementation of List broke backward compatibility for programs that pass an element from the list by reference to the constructor pushing to the list. This happens because reallocating moves the data from the location that is still referred to, leading to zeroed input to the constructor called in pushConstruct. While it would be possible to store the new element on the stack before reallocating, this can already be done manually by calling push instead of pushConstruct when the performance penalty is acceptable, which is more future proof than depending on exact operation order inside of the pushConstruct method. Implementing a push operation that moves the input instead of copying might be either faster or pointless overlap with compiler optimizations.