### PR TITLE
Fixed wrong template arguments for faded vertex color

### DIFF
--- a/Source/DFPSR/implementation/render/shader/RgbaMultiply.h
+++ b/Source/DFPSR/implementation/render/shader/RgbaMultiply.h
@@ -133,7 +133,7 @@ static void processTriangle_RgbaMultiply(const TriangleInput &triangleInput, con
 		} else {
 			if (hasVertexFade) { // DiffuseVertex
 				if (hasDiffusePyramid) { // With mipmap
-					fillShape(&data, getPixels_2x2<false, false, false, false, false>, colorBuffer, depthBuffer, triangle, projection, shape, filter);
+					fillShape(&data, getPixels_2x2<true, false, false, true, false>, colorBuffer, depthBuffer, triangle, projection, shape, filter);
 				} else { // Without mipmap
 					fillShape(&data, getPixels_2x2<true, true, false, true, false>, colorBuffer, depthBuffer, triangle, projection, shape, filter);
 				}
@@ -142,7 +142,7 @@ static void processTriangle_RgbaMultiply(const TriangleInput &triangleInput, con
 					if (hasDiffusePyramid) { // With mipmap
 						fillShape(&data, getPixels_2x2<true, false, false, false, true>, colorBuffer, depthBuffer, triangle, projection, shape, filter);
 					} else { // Without mipmap
-					fillShape(&data, getPixels_2x2<true, true, false, false, true>, colorBuffer, depthBuffer, triangle, projection, shape, filter);
+						fillShape(&data, getPixels_2x2<true, true, false, false, true>, colorBuffer, depthBuffer, triangle, projection, shape, filter);
 					}
 				} else { // Diffuse
 					if (hasDiffusePyramid) { // With mipmap


### PR DESCRIPTION
Using vertex colors in the 3D model editor revealed incorrect template arguments in the multiply shader, for the optimized special case when a triangle has multiple mip layers of diffuse texture, no light map, and multiple vertex colors.

Looked through all the arguments to ensure that all arguments are consistent with the if statements, but regression tests might be needed to detect if the shader breaks again.