### PR TITLE
Inheriting theme from parent component

### DIFF
--- a/Source/DFPSR/implementation/gui/VisualComponent.cpp
+++ b/Source/DFPSR/implementation/gui/VisualComponent.cpp
@@ -265,6 +265,8 @@ void VisualComponent::addChildComponent(Handle<VisualComponent> child) {
 		child->detachFromParent();
 		// Update layout based on the new parent size
 		child->applyLayout(IRect(0, 0, this->location.width(), this->location.height()));
+		// Let the new component inherit the theme from its parent.
+		child->applyTheme(this->getTheme());
 		// Connect to the new parent
 		this->children.push(child);
 		this->childChanged = true;
@@ -281,6 +283,8 @@ bool VisualComponent::addChild(Handle<Persistent> child) {
 		return false; // Wrong type!
 	} else {
 		this->addChildComponent(visualComponent);
+		// Let the new component inherit the theme from its parent.
+		visualComponent->applyTheme(this->getTheme());
 		return true; // Success!
 	}
 }


### PR DESCRIPTION
This makes sure that the theme does not change into the default theme when procedurally inserting more components to a graphical user interface that has already selected a theme.