### PR TITLE
Found a bug in clamping of mipLevel in texture_sample_bilinear

### DIFF
--- a/Source/DFPSR/implementation/render/shader/RgbaMultiply.h
+++ b/Source/DFPSR/implementation/render/shader/RgbaMultiply.h
@@ -78,12 +78,12 @@ inline Rgba_F32<U32x4, F32x4> getPixels_2x2(void *data, const F32x4x3 &vertexWei
 		// Optimized for diffuse only
 		F32x4 u1 = shaderMethods::interpolate(assets->texCoords.u1, vertexWeights);
 		F32x4 v1 = shaderMethods::interpolate(assets->texCoords.v1, vertexWeights);
-		return shaderMethods::sample_F32<Interpolation::BL, false, DIFFUSE_SINGLE_LAYER, false, false, false>(assets->diffuseMap, u1, v1);
+		return shaderMethods::sample_F32<Interpolation::BL, false, DIFFUSE_SINGLE_LAYER, false, false>(assets->diffuseMap, u1, v1);
 	} else if (HAS_LIGHT_MAP && !HAS_DIFFUSE_MAP && COLORLESS) {
 		// Optimized for light only
 		F32x4 u2 = shaderMethods::interpolate(assets->texCoords.u2, vertexWeights);
 		F32x4 v2 = shaderMethods::interpolate(assets->texCoords.v2, vertexWeights);
-		return shaderMethods::sample_F32<Interpolation::BL, false, false, false, false, true>(assets->lightMap, u2, v2);
+		return shaderMethods::sample_F32<Interpolation::BL, false, false, false, true>(assets->lightMap, u2, v2);
 	} else {
 		// Interpolate the vertex color
 		Rgba_F32<U32x4, F32x4> color = HAS_VERTEX_FADING ?
@@ -93,13 +93,13 @@ inline Rgba_F32<U32x4, F32x4> getPixels_2x2(void *data, const F32x4x3 &vertexWei
 		if (HAS_DIFFUSE_MAP) {
 			F32x4 u1 = shaderMethods::interpolate(assets->texCoords.u1, vertexWeights);
 			F32x4 v1 = shaderMethods::interpolate(assets->texCoords.v1, vertexWeights);
-			color = color * shaderMethods::sample_F32<Interpolation::BL, false, DIFFUSE_SINGLE_LAYER, false, false, false>(assets->diffuseMap, u1, v1);
+			color = color * shaderMethods::sample_F32<Interpolation::BL, false, DIFFUSE_SINGLE_LAYER, false, false>(assets->diffuseMap, u1, v1);
 		}
 		// Sample lightmap
 		if (HAS_LIGHT_MAP) {
 			F32x4 u2 = shaderMethods::interpolate(assets->texCoords.u2, vertexWeights);
 			F32x4 v2 = shaderMethods::interpolate(assets->texCoords.v2, vertexWeights);
-			color = color * shaderMethods::sample_F32<Interpolation::BL, false, false, false, false, true>(assets->lightMap, u2, v2);
+			color = color * shaderMethods::sample_F32<Interpolation::BL, false, false, false, true>(assets->lightMap, u2, v2);
 		}
 		return color;
 	}

--- a/Source/DFPSR/implementation/render/shader/shaderMethods.h
+++ b/Source/DFPSR/implementation/render/shader/shaderMethods.h
@@ -61,24 +61,24 @@ namespace shaderMethods {
 	  bool SQUARE = false,
 	  bool SINGLE_LAYER = false,
 	  bool XY_INSIDE = false,
-	  bool MIP_INSIDE = false,
 	  bool HIGHEST_RESOLUTION = false
 	>
 	inline U32x4 sample_U32(const TextureRgbaU8 &source, const F32x4 &u, const F32x4 &v) {
+		// Because constant level 0 and the result of texture_getMipLevelIndex will be within bound, we can assume that the MIP level is inside and set MIP_INSIDE to true.
 		if (INTERPOLATION == Interpolation::NN) {
 			if (HIGHEST_RESOLUTION) {
-				return texture_sample_nearest<SQUARE, SINGLE_LAYER, MIP_INSIDE, HIGHEST_RESOLUTION>(source, u, v, 0u);
+				return texture_sample_nearest<SQUARE, SINGLE_LAYER, true, HIGHEST_RESOLUTION>(source, u, v, 0u);
 			} else {
 				// TODO: Calculate MIP levels using a separate rendering stage with sparse resolution writing results into thread-local memory.
 				uint32_t mipLevel = texture_getMipLevelIndex<F32x4>(source, u, v);
-				return texture_sample_nearest<SQUARE, SINGLE_LAYER, MIP_INSIDE, HIGHEST_RESOLUTION>(source, u, v, mipLevel);
+				return texture_sample_nearest<SQUARE, SINGLE_LAYER, true, HIGHEST_RESOLUTION>(source, u, v, mipLevel);
 			}
 		} else {
 			if (HIGHEST_RESOLUTION) {
-				return texture_sample_bilinear<SQUARE, SINGLE_LAYER, MIP_INSIDE, HIGHEST_RESOLUTION>(source, u, v, 0u);
+				return texture_sample_bilinear<SQUARE, SINGLE_LAYER, true, HIGHEST_RESOLUTION>(source, u, v, 0u);
 			} else {
 				uint32_t mipLevel = texture_getMipLevelIndex<F32x4>(source, u, v);
-				return texture_sample_bilinear<SQUARE, SINGLE_LAYER, MIP_INSIDE, HIGHEST_RESOLUTION>(source, u, v, mipLevel);
+				return texture_sample_bilinear<SQUARE, SINGLE_LAYER, true, HIGHEST_RESOLUTION>(source, u, v, mipLevel);
 			}
 		}
 	}
@@ -87,11 +87,10 @@ namespace shaderMethods {
 	  bool SQUARE = false,
 	  bool SINGLE_LAYER = false,
 	  bool XY_INSIDE = false,
-	  bool MIP_INSIDE = false,
 	  bool HIGHEST_RESOLUTION = false
 	>
 	inline Rgba_F32<U32x4, F32x4> sample_F32(const TextureRgbaU8 &source, const F32x4 &u, const F32x4 &v) {
-		return Rgba_F32<U32x4, F32x4>(sample_U32<INTERPOLATION, SQUARE, SINGLE_LAYER, XY_INSIDE, MIP_INSIDE, HIGHEST_RESOLUTION>(source, u, v));
+		return Rgba_F32<U32x4, F32x4>(sample_U32<INTERPOLATION, SQUARE, SINGLE_LAYER, XY_INSIDE, HIGHEST_RESOLUTION>(source, u, v));
 	}
 }
 


### PR DESCRIPTION
Patching it by clamping the MIP level based on the available levels in the pyramid and making MIP_INSIDE mandatory for bi-linear sampling. I will probably keep setting MIP_INSIDE to true for the 3D rendering anyway, for the performance gain of only clamping it once per group of 2x2 pixels, but for anyone calling bi-linear texture sampling directly without MIP_INSIDE, a better fix with new SIMD functions for integer minimum and maximum with a scalar fallback will be needed to simplify the texture sampling.