### PR TITLE
Fixed a bug in threadedWorkFromList

### DIFF
--- a/Source/DFPSR/base/threading.cpp
+++ b/Source/DFPSR/base/threading.cpp
@@ -182,7 +182,9 @@ void threadedWorkFromArray(SafePointer<std::function<void()>> jobs, int jobCount
 }
 
 void threadedWorkFromList(List<std::function<void()>> jobs, int maxThreadCount) {
-	threadedWorkFromArray(&jobs[0], jobs.length(), maxThreadCount);
+	if (jobs.length() > 0) {
+		threadedWorkFromArray(&jobs[0], jobs.length(), maxThreadCount);
+	}
 	jobs.clear();
 }
 


### PR DESCRIPTION
Despite abstracting on top of functions that handle the empty case and not using the first element, it still triggered a false bound execption from requesting a reference to the first element, because the [] operator is tied to the bound check even if you just want a pointer to the buffer as a whole.