### PR TITLE
Made it optional to zero new memory in buffers and images

### DIFF
--- a/Source/DFPSR/api/bufferAPI.cpp
+++ b/Source/DFPSR/api/bufferAPI.cpp
@@ -36,13 +36,13 @@ Buffer buffer_create(intptr_t newSize) {
 	return handle_createArray<uint8_t>(AllocationInitialization::Zeroed, (uintptr_t)newSize);
 }
 
-Buffer buffer_create(intptr_t newSize, uintptr_t paddToAlignment) {
+Buffer buffer_create(intptr_t newSize, uintptr_t paddToAlignment, bool zeroed) {
 	if (newSize < 0) newSize = 0;
 	if (paddToAlignment > heap_getHeapAlignment()) {
 		throwError(U"Maximum alignment exceeded when creating a buffer!\n");
 		return Handle<uint8_t>();
 	} else {
-		return handle_createArray<uint8_t>(AllocationInitialization::Zeroed, memory_getPaddedSize((uintptr_t)newSize, paddToAlignment));
+		return handle_createArray<uint8_t>(zeroed ? AllocationInitialization::Zeroed : AllocationInitialization::Uninitialized, memory_getPaddedSize((uintptr_t)newSize, paddToAlignment));
 	}
 }
 

--- a/Source/DFPSR/api/bufferAPI.h
+++ b/Source/DFPSR/api/bufferAPI.h
@@ -63,7 +63,7 @@ namespace dsr {
 	// Allocate a Buffer with padding.
 	// The buffer always align the start with heap alignment, but this function makes sure that paddToAlignment does not exceed heap alignment.
 	// Pre-condition: paddToAlignment <= heap_getHeapAlignment()
-	Buffer buffer_create(intptr_t newSize, uintptr_t paddToAlignment);
+	Buffer buffer_create(intptr_t newSize, uintptr_t paddToAlignment, bool zeroed = true);
 
 	// Sets the allocation's destructor, to be called when there are no more reference counted pointers to the buffer.
 	//   The destructor is not responsible for freeing the memory allocation itself, only calling destructors in the content.

--- a/Source/DFPSR/api/filterAPI.cpp
+++ b/Source/DFPSR/api/filterAPI.cpp
@@ -289,10 +289,10 @@ static void resize_aux(const ImageU8& target, const ImageU8& source, bool interp
 
 // Creating an image to replacedImage with the same pack order as originalImage when applicable to the image format.
 static ImageRgbaU8 createWithSamePackOrder(const ImageRgbaU8& originalImage, int32_t width, int32_t height) {
-	return image_create_RgbaU8_native(width, height, image_getPackOrderIndex(originalImage));
+	return image_create_RgbaU8_native(width, height, image_getPackOrderIndex(originalImage), false);
 }
 static ImageU8 createWithSamePackOrder(const ImageU8& originalImage, int32_t width, int32_t height) {
-	return image_create_U8(width, height);
+	return image_create_U8(width, height, false);
 }
 
 template <typename IMAGE_TYPE>
@@ -776,7 +776,7 @@ void filter_mapRgbaU8(const ImageRgbaU8 &target, const ImageGenRgbaU8& lambda, i
 	}
 }
 OrderedImageRgbaU8 filter_generateRgbaU8(int width, int height, const ImageGenRgbaU8& lambda, int startX, int startY) {
-	OrderedImageRgbaU8 result = image_create_RgbaU8(width, height);
+	OrderedImageRgbaU8 result = image_create_RgbaU8(width, height, false);
 	filter_mapRgbaU8(result, lambda, startX, startY);
 	return result;
 }
@@ -805,7 +805,7 @@ void filter_mapU8(const ImageU8 &target, const ImageGenI32& lambda, int startX, 
 	}
 }
 AlignedImageU8 filter_generateU8(int width, int height, const ImageGenI32& lambda, int startX, int startY) {
-	AlignedImageU8 result = image_create_U8(width, height);
+	AlignedImageU8 result = image_create_U8(width, height, false);
 	filter_mapU8(result, lambda, startX, startY);
 	return result;
 }
@@ -815,7 +815,7 @@ void filter_mapU16(const ImageU16 &target, const ImageGenI32& lambda, int startX
 	}
 }
 AlignedImageU16 filter_generateU16(int width, int height, const ImageGenI32& lambda, int startX, int startY) {
-	AlignedImageU16 result = image_create_U16(width, height);
+	AlignedImageU16 result = image_create_U16(width, height, false);
 	filter_mapU16(result, lambda, startX, startY);
 	return result;
 }
@@ -840,7 +840,7 @@ void filter_mapF32(const ImageF32 &target, const ImageGenF32& lambda, int startX
 	}
 }
 AlignedImageF32 filter_generateF32(int width, int height, const ImageGenF32& lambda, int startX, int startY) {
-	AlignedImageF32 result = image_create_F32(width, height);
+	AlignedImageF32 result = image_create_F32(width, height, false);
 	filter_mapF32(result, lambda, startX, startY);
 	return result;
 }
@@ -851,7 +851,7 @@ AlignedImageF32 filter_generateF32(int width, int height, const ImageGenF32& lam
 
 OrderedImageRgbaU8 filter_resize(const ImageRgbaU8 &source, Sampler interpolation, int32_t newWidth, int32_t newHeight) {
 	if (image_exists(source)) {
-		OrderedImageRgbaU8 resultImage = image_create_RgbaU8(newWidth, newHeight);
+		OrderedImageRgbaU8 resultImage = image_create_RgbaU8(newWidth, newHeight, false);
 		resizeToTarget<ImageRgbaU8>(resultImage, source, interpolation == Sampler::Linear);
 		return resultImage;
 	} else {
@@ -861,7 +861,7 @@ OrderedImageRgbaU8 filter_resize(const ImageRgbaU8 &source, Sampler interpolatio
 
 AlignedImageU8 filter_resize(const ImageU8 &source, Sampler interpolation, int32_t newWidth, int32_t newHeight) {
 	if (image_exists(source)) {
-		AlignedImageU8 resultImage = image_create_U8(newWidth, newHeight);
+		AlignedImageU8 resultImage = image_create_U8(newWidth, newHeight, false);
 		resizeToTarget<ImageU8>(resultImage, source, interpolation == Sampler::Linear);
 		return resultImage;
 	} else {

--- a/Source/DFPSR/api/imageAPI.cpp
+++ b/Source/DFPSR/api/imageAPI.cpp
@@ -39,7 +39,7 @@ static const int32_t maximumImageWidth = 65536;
 static const int32_t maximumImageHeight = 65536;
 
 template <typename IMAGE_TYPE>
-IMAGE_TYPE image_create_template(const char * name, int32_t width, int32_t height, PackOrderIndex packOrderIndex) {
+IMAGE_TYPE image_create_template(const char * name, int32_t width, int32_t height, PackOrderIndex packOrderIndex, bool zeroed) {
 	if (width < 1 || width > maximumImageWidth || height < 1 || height > maximumImageHeight) {
 		sendWarning(U"");
 		// Return an empty image on failure.
@@ -50,29 +50,29 @@ IMAGE_TYPE image_create_template(const char * name, int32_t width, int32_t heigh
 		uintptr_t byteStride = memory_getPaddedSize(width * pixelSize, heap_getHeapAlignment());
 		uint32_t pixelStride = byteStride / pixelSize;
 		// Create the image.
-		return IMAGE_TYPE(buffer_create(byteStride * height).setName(name), 0, width, height, pixelStride, packOrderIndex);
+		return IMAGE_TYPE(buffer_create(byteStride * height, 1, zeroed).setName(name), 0, width, height, pixelStride, packOrderIndex);
 	}
 }
 
 // Take the dimensions as signed integers to avoid getting extreme dimensions on underflow.
-AlignedImageU8 image_create_U8(int32_t width, int32_t height) {
-	return image_create_template<AlignedImageU8>("U8 pixel buffer", width, height, PackOrderIndex::RGBA);
+AlignedImageU8 image_create_U8(int32_t width, int32_t height, bool zeroed) {
+	return image_create_template<AlignedImageU8>("U8 pixel buffer", width, height, PackOrderIndex::RGBA, zeroed);
 }
 
-AlignedImageU16 image_create_U16(int32_t width, int32_t height) {
-	return image_create_template<AlignedImageU16>("U16 pixel buffer", width, height, PackOrderIndex::RGBA);
+AlignedImageU16 image_create_U16(int32_t width, int32_t height, bool zeroed) {
+	return image_create_template<AlignedImageU16>("U16 pixel buffer", width, height, PackOrderIndex::RGBA, zeroed);
 }
 
-AlignedImageF32 image_create_F32(int32_t width, int32_t height) {
-	return image_create_template<AlignedImageF32>("F32 pixel buffer", width, height, PackOrderIndex::RGBA);
+AlignedImageF32 image_create_F32(int32_t width, int32_t height, bool zeroed) {
+	return image_create_template<AlignedImageF32>("F32 pixel buffer", width, height, PackOrderIndex::RGBA, zeroed);
 }
 
-OrderedImageRgbaU8 image_create_RgbaU8(int32_t width, int32_t height) {
-	return image_create_template<OrderedImageRgbaU8>("RgbaU8 pixel buffer", width, height, PackOrderIndex::RGBA);
+OrderedImageRgbaU8 image_create_RgbaU8(int32_t width, int32_t height, bool zeroed) {
+	return image_create_template<OrderedImageRgbaU8>("RgbaU8 pixel buffer", width, height, PackOrderIndex::RGBA, zeroed);
 }
 
-AlignedImageRgbaU8 image_create_RgbaU8_native(int32_t width, int32_t height, PackOrderIndex packOrderIndex) {
-	return image_create_template<OrderedImageRgbaU8>("Native pixel buffer", width, height, packOrderIndex);
+AlignedImageRgbaU8 image_create_RgbaU8_native(int32_t width, int32_t height, PackOrderIndex packOrderIndex, bool zeroed) {
+	return image_create_template<OrderedImageRgbaU8>("Native pixel buffer", width, height, packOrderIndex, zeroed);
 }
 
 // Pre-condition: image exists.

--- a/Source/DFPSR/api/imageAPI.h
+++ b/Source/DFPSR/api/imageAPI.h
@@ -41,11 +41,14 @@ namespace dsr {
 	//   1 <= height <= 65536
 	// Post-condition:
 	//   Returns a new image of width x height pixels, or an empty image on failure.
-	AlignedImageU8 image_create_U8(int32_t width, int32_t height);
-	AlignedImageU16 image_create_U16(int32_t width, int32_t height);
-	AlignedImageF32 image_create_F32(int32_t width, int32_t height);
-	OrderedImageRgbaU8 image_create_RgbaU8(int32_t width, int32_t height);
-	AlignedImageRgbaU8 image_create_RgbaU8_native(int32_t width, int32_t height, PackOrderIndex packOrderIndex);
+	// Warning: Setting zeroed to false will initialize the image with non-deterministic pixel data.
+	//          This can make execution faster but also complicate tracking down errors.
+	//          Only recommended for temporary images when you know for sure that all content will be overwritten.
+	AlignedImageU8 image_create_U8(int32_t width, int32_t height, bool zeroed = true);
+	AlignedImageU16 image_create_U16(int32_t width, int32_t height, bool zeroed = true);
+	AlignedImageF32 image_create_F32(int32_t width, int32_t height, bool zeroed = true);
+	OrderedImageRgbaU8 image_create_RgbaU8(int32_t width, int32_t height, bool zeroed = true);
+	AlignedImageRgbaU8 image_create_RgbaU8_native(int32_t width, int32_t height, PackOrderIndex packOrderIndex, bool zeroed = true);
 
 // Properties
 	// Returns image's width in pixels, or 0 from an empty image


### PR DESCRIPTION
Dangerous to disable by exposing uninitialized data, but sometimes you need a temporary image quickly and will overwrite the content before reading it.