### PR TITLE
Camera, projection and trait fixes

### DIFF
--- a/Source/DFPSR/base/DsrTraits.h
+++ b/Source/DFPSR/base/DsrTraits.h
@@ -36,9 +36,9 @@
 			static constexpr T value = VALUE;
 		};
 		// Custom implementation of std::false_type.
-		using DSR_TRAIT_FALSE = DSR_PROPERTY<bool, false>;
+		using DSR_TRAIT_FALSE = dsr::DSR_PROPERTY<bool, false>;
 		// Custom implementation of std::true_type.
-		using DSR_TRAIT_TRUE = DSR_PROPERTY<bool, true>;
+		using DSR_TRAIT_TRUE = dsr::DSR_PROPERTY<bool, true>;
 		// Custom implementation of std::is_same.
 		template <typename T, typename U>
 		struct DsrTrait_SameType { static const bool value = false; };
@@ -54,30 +54,30 @@
 
 		// Place this as a template argument to disable the template function when false.
 		#define DSR_ENABLE_IF(TRAIT) \
-			typename = typename DsrTrait_EnableIf<TRAIT>::type 
+			typename = typename dsr::DsrTrait_EnableIf<TRAIT>::type 
 
 		// Properties are given to single types.
 		#define DSR_DECLARE_PROPERTY(PROPERTY_NAME) \
-			template <typename T> struct PROPERTY_NAME : DSR_TRAIT_FALSE {};
+			template <typename T> struct PROPERTY_NAME : dsr::DSR_TRAIT_FALSE {};
 
 		#define DSR_APPLY_PROPERTY(PROPERTY_NAME, TYPE_NAME) \
-			template <> struct PROPERTY_NAME<TYPE_NAME> : DSR_TRAIT_TRUE  {};
+			template <> struct PROPERTY_NAME<TYPE_NAME> : dsr::DSR_TRAIT_TRUE  {};
 
 		#define DSR_CHECK_PROPERTY(PROPERTY_NAME, TYPE_NAME) \
 			(PROPERTY_NAME<TYPE_NAME>::value)
 
 		// Relations are given to pairs of types.
 		#define DSR_DECLARE_RELATION(RELATION_NAME) \
-			template <typename T, typename U> struct RELATION_NAME : DSR_TRAIT_FALSE {};
+			template <typename T, typename U> struct RELATION_NAME : dsr::DSR_TRAIT_FALSE {};
 
 		#define DSR_APPLY_RELATION(RELATION_NAME, TYPE_A, TYPE_B) \
-			template <> struct RELATION_NAME<TYPE_A, TYPE_B> : DSR_TRAIT_TRUE  {};
+			template <> struct RELATION_NAME<TYPE_A, TYPE_B> : dsr::DSR_TRAIT_TRUE  {};
 
 		#define DSR_CHECK_RELATION(RELATION_NAME, TYPE_A, TYPE_B) \
 			(RELATION_NAME<TYPE_A, TYPE_B>::value)
 
 		// Checking types.
-		#define DSR_SAME_TYPE(TYPE_A, TYPE_B) DsrTrait_SameType<TYPE_A, TYPE_B>::value
+		#define DSR_SAME_TYPE(TYPE_A, TYPE_B) dsr::DsrTrait_SameType<TYPE_A, TYPE_B>::value
 		#define DSR_CONVERTIBLE_TO(FROM, TO) std::is_convertible<FROM, TO>::value
 		#define DSR_UTF32_LITERAL(TYPE) std::is_convertible<TYPE, const char32_t*>::value
 		#define DSR_ASCII_LITERAL(TYPE) std::is_convertible<TYPE, const char*>::value

--- a/Source/DFPSR/implementation/render/Camera.h
+++ b/Source/DFPSR/implementation/render/Camera.h
@@ -37,13 +37,6 @@
 
 namespace dsr {
 
-// A special rounding used for vertex projection
-static inline int64_t safeRoundInt64(float value) {
-	int64_t result = (int64_t)value;
-	if (value <= -1048576.0f || value >= 1048576.0f) { result = 0; }
-	return result;
-}
-
 class ViewFrustum {
 private:
 	FPlane3D planes[6];
@@ -179,7 +172,7 @@ public:
 			);
 			FVector2D projectedFloat = preProjection * invDepth;
 			FVector2D subPixel = projectedFloat * constants::unitsPerPixel;
-			LVector2D rounded = LVector2D(safeRoundInt64(subPixel.x), safeRoundInt64(subPixel.y));
+			LVector2D rounded = LVector2D(int64_t(subPixel.x), int64_t(subPixel.y));
 			return ProjectedPoint(cameraSpace, projectedFloat, rounded);
 		} else {
 			FVector2D projectedFloat = FVector2D(
@@ -187,7 +180,7 @@ public:
 			  (-cameraSpace.y * this->invHeightSlope + 0.5f) * this->imageHeight
 			);
 			FVector2D subPixel = projectedFloat * constants::unitsPerPixel;
-			LVector2D rounded = LVector2D(safeRoundInt64(subPixel.x), safeRoundInt64(subPixel.y));
+			LVector2D rounded = LVector2D(int64_t(subPixel.x), int64_t(subPixel.y));
 			return ProjectedPoint(cameraSpace, projectedFloat, rounded);
 		}
 	}

--- a/Source/DFPSR/implementation/render/Camera.h
+++ b/Source/DFPSR/implementation/render/Camera.h
@@ -49,27 +49,34 @@ private:
 	FPlane3D planes[6];
 	int planeCount;
 public:
+	// Named indices to the different planes defining a view frustum.
+	static const int view_left   = 0;
+	static const int view_right  = 1;
+	static const int view_top    = 2;
+	static const int view_bottom = 3;
+	static const int view_near   = 4;
+	static const int view_far    = 5;
 	ViewFrustum() : planeCount(0) {}
 	// Orthogonal view frustum in camera space
 	ViewFrustum(float halfWidth, float halfHeight)
 	: planeCount(4) {
 		// Sides
-		planes[0] = FPlane3D(FVector3D(1.0f, 0.0f, 0.0f), halfWidth);
-		planes[1] = FPlane3D(FVector3D(-1.0f, 0.0f, 0.0f), halfWidth);
-		planes[2] = FPlane3D(FVector3D(0.0f, 1.0f, 0.0f), halfHeight);
-		planes[3] = FPlane3D(FVector3D(0.0f, -1.0f, 0.0f), halfHeight);
+		planes[view_left  ] = FPlane3D(FVector3D(-1.0f, 0.0f, 0.0f), halfWidth);
+		planes[view_right ] = FPlane3D(FVector3D(1.0f, 0.0f, 0.0f), halfWidth);
+		planes[view_top   ] = FPlane3D(FVector3D(0.0f, 1.0f, 0.0f), halfHeight);
+		planes[view_bottom] = FPlane3D(FVector3D(0.0f, -1.0f, 0.0f), halfHeight);
 	}
 	// Perspective view frustum in camera space
 	ViewFrustum(float nearClip, float farClip, float widthSlope, float heightSlope)
 	: planeCount(farClip == std::numeric_limits<float>::infinity() ? 5 : 6) { // Skip the far clip plane if its distance is infinite.
 		// Sides
-		planes[0] = FPlane3D(FVector3D(1.0f, 0.0f, -widthSlope), 0.0f);
-		planes[1] = FPlane3D(FVector3D(-1.0f, 0.0f, -widthSlope), 0.0f);
-		planes[2] = FPlane3D(FVector3D(0.0f, 1.0f, -heightSlope), 0.0f);
-		planes[3] = FPlane3D(FVector3D(0.0f, -1.0f, -heightSlope), 0.0f);
+		planes[view_left  ] = FPlane3D(FVector3D(-1.0f,  0.0f, -widthSlope ), 0.0f);
+		planes[view_right ] = FPlane3D(FVector3D( 1.0f,  0.0f, -widthSlope ), 0.0f);
+		planes[view_top   ] = FPlane3D(FVector3D( 0.0f,  1.0f, -heightSlope), 0.0f);
+		planes[view_bottom] = FPlane3D(FVector3D( 0.0f, -1.0f, -heightSlope), 0.0f);
 		// Near and far clip planes
-		planes[4] = FPlane3D(FVector3D(0.0f, 0.0f, -1.0f), -nearClip);
-		planes[5] = FPlane3D(FVector3D(0.0f, 0.0f, 1.0f), farClip);
+		planes[view_near  ] = FPlane3D(FVector3D(0.0f, 0.0f, -1.0f), -nearClip);
+		planes[view_far   ] = FPlane3D(FVector3D(0.0f, 0.0f,  1.0f),   farClip);
 	}
 	inline int getPlaneCount() const {
 		return this->planeCount;


### PR DESCRIPTION
Fixed some things while developing the detail tesselation engine.

Now it should be possible to refer to specific planes in a view frustum using named indices, which makes it easier to write custom culling and clipping algorithms where each side is treated differently.

Removed a resolution limit in camera projections, so that one can attempt to increase the resolution as much as possible until the specific rasterization algorithm fails.

Made it possible to use traits outside of the namespace, by using dsr:: explicitly from macros that have no namespace.