### PR TITLE
Created algorithmAPI_List.h

### DIFF
--- a/Doc/Dictionary.html
+++ b/Doc/Dictionary.html
@@ -90,6 +90,11 @@ Doc | Documentation
 Gen | Generator, a function or program used to create something automatically.
 
 </P><P>
+Iff | Short form for "if and only if", which is used to constrain boolean outputs.
+The "if and only if" expression is used instead of having to write explicitly that a function returns false when the criteria for returning true is not met.
+If only defining when a function should return true and not when it should return false, a function always returning true will satisfy the post-condition by returning true when the condition is met.
+
+</P><P>
 </P><IMG SRC="Images/Border.png"><P>
 
 </P><P>

--- a/Doc/Text/Dictionary.txt
+++ b/Doc/Text/Dictionary.txt
@@ -48,6 +48,10 @@ Doc | Documentation
 
 Gen | Generator, a function or program used to create something automatically.
 
+Iff | Short form for "if and only if", which is used to constrain boolean outputs.
+The "if and only if" expression is used instead of having to write explicitly that a function returns false when the criteria for returning true is not met.
+If only defining when a function should return true and not when it should return false, a function always returning true will satisfy the post-condition by returning true when the condition is met.
+
 ---
 
 Title2: Expressions

--- a/Source/DFPSR/api/algorithmAPI.h
+++ b/Source/DFPSR/api/algorithmAPI.h
@@ -1,6 +1,6 @@
 ﻿// zlib open source license
 //
-// Copyright (c) 2023 David Forsgren Piuva
+// Copyright (c) 2023 to 2026 David Forsgren Piuva
 // 
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -24,136 +24,11 @@
 #ifndef DFPSR_API_ALGORITHM
 #define DFPSR_API_ALGORITHM
 
-// TODO: Split Algorithm into smaller APIs for specific types and only have the methods that need more than one collection type in the exposed API.
-//       This allow using the algorithm API for a specific type without bloating the dependencies with all the types and their functions.
-#include "../collection/List.h"
-#include "../collection/Array.h"
-#include "../collection/Field.h"
-#include "../collection/FixedArray.h"
+#include "algorithmAPI_List.h"
+#include "algorithmAPI_Array.h"
+#include "algorithmAPI_Field.h"
+#include "algorithmAPI_FixedArray.h"
 
-namespace dsr {
-
-// Returns true iff a and b are equal in length and content according to T's equality operator.
-template<typename T>
-bool operator==(const List<T>& a, const List<T>& b) {
-	if (a.length() != b.length()) return false;
-	for (intptr_t i = 0; i < a.length(); i++) {
-		if (!(a[i] == b[i])) return false;
-	}
-	return true;
-}
-
-// Returns true iff a and b are equal in length and content according to T's equality operator.
-template<typename T>
-bool operator==(const Array<T>& a, const Array<T>& b) {
-	if (a.length() != b.length()) return false;
-	for (intptr_t i = 0; i < a.length(); i++) {
-		if (!(a[i] == b[i])) return false;
-	}
-	return true;
-}
-
-// Returns true iff a and b are equal in content according to T's equality operator.
-// If the lengths do not match, the call will not be compiled.
-template<typename T, intptr_t LENGTH>
-bool operator==(const FixedArray<T, LENGTH>& a, const FixedArray<T, LENGTH>& b) {
-	for (intptr_t i = 0; i < LENGTH; i++) {
-		if (!(a[i] == b[i])) return false;
-	}
-	return true;
-}
-
-// Returns true iff a and b have the same dimensions and content according to T's equality operator.
-template<typename T>
-bool operator==(const Field<T>& a, const Field<T>& b) {
-	if (a.width() != b.width()
-	 || a.height() != b.height()) return false;
-	for (intptr_t y = 0; y < a.height(); y++) {
-		for (intptr_t x = 0; x < a.width(); x++) {
-			if (!(a.unsafe_readAccess(x, y) == b.unsafe_readAccess(x, y))) return false;
-		}
-	}
-	return true;
-}
-
-// Returns false iff a and b are equal in length and content according to T's equality operator.
-template<typename T> bool operator!=(const List<T>& a, const List<T>& b) { return !(a == b); }
-
-// Returns false iff a and b are equal in length and content according to T's equality operator.
-template<typename T> bool operator!=(const Array<T>& a, const Array<T>& b) { return !(a == b); }
-
-// Returns false iff a and b are equal in content according to T's equality operator.
-template<typename T, intptr_t LENGTH> bool operator!=(const FixedArray<T, LENGTH>& a, const FixedArray<T, LENGTH>& b) { return !(a == b); }
-
-// Returns false iff a and b have the same dimensions and content according to T's equality operator.
-template<typename T> bool operator!=(const Field<T>& a, const Field<T>& b) { return !(a == b); }
-
-// Internal helper function
-template<typename T>
-String& print_collection_1D_multiline(String& target, const T& collection, const ReadableString& indentation) {
-	string_append(target, indentation, U"{\n");
-	intptr_t maxIndex = collection.length() - 1;
-	for (intptr_t i = 0; i <= maxIndex; i++) {
-		string_toStreamIndented(target, collection[i], indentation + U"\t");
-		if (i < maxIndex) {
-			string_append(target, U",");
-		}
-		string_append(target, U"\n");
-	}
-	string_append(target, indentation, U"}");
-	return target;
-}
-
-// Printing a generic List of elements for easy debugging.
-//   A new line is used after each element, because the element type might print using multiple lines and the list might be very long.
-//   No new line at the end, because the caller might want to add a comma before breaking the line.
-//   If string_toStreamIndented is defined for lists of a specific element type, this template function will be overridden by the more specific function.
-template<typename T>
-String& string_toStreamIndented(String& target, const List<T>& collection, const ReadableString& indentation) {
-	return print_collection_1D_multiline(target, collection, indentation);
-}
-
-// Printing a generic Array of elements for easy debugging, using the same syntax as when printing List.
-template<typename T>
-String& string_toStreamIndented(String& target, const Array<T>& collection, const ReadableString& indentation) {
-	return print_collection_1D_multiline(target, collection, indentation);
-}
-
-// Printing a generic FixedArray of elements for easy debugging, using the same syntax as when printing List.
-template<typename T, intptr_t LENGTH>
-String& string_toStreamIndented(String& target, const FixedArray<T, LENGTH>& collection, const ReadableString& indentation) {
-	return print_collection_1D_multiline(target, collection, indentation);
-}
-
-// Printing a generic Field of elements for easy debugging.
-template<typename T>
-String& string_toStreamIndented(String& target, const Field<T>& collection, const ReadableString& indentation) {
-	string_append(target, indentation, U"{\n");
-	intptr_t maxX = collection.width() - 1;
-	intptr_t maxY = collection.height() - 1;
-	for (intptr_t y = 0; y <= maxY; y++) {
-		string_append(target, indentation, U"\t{\n");
-		for (intptr_t x = 0; x <= maxX; x++) {
-			string_toStreamIndented(target, collection.unsafe_readAccess(IVector2D(x, y)), indentation + U"\t\t");
-			if (x < maxX) {
-				string_append(target, U",");
-			}
-			string_append(target, U"\n");
-		}
-		string_append(target, indentation, U"\t}");
-		if (y < maxY) {
-			string_append(target, U",");
-		}
-		string_append(target, U"\n");
-	}
-	string_append(target, indentation, U"}");
-	return target;
-}
-
-// TODO: Implement functional sort, concatenation, union, search and conversion algorithms for List, Array, Field and FixedArray.
-//       in a separate "algorithm" API that does not have to be exposed in headers when using the collection types.
-
-}
+// TODO: Implement algorithms that require more than one of the collection types here.
 
 #endif
-

--- a/Source/DFPSR/api/algorithmAPI_Array.h
+++ b/Source/DFPSR/api/algorithmAPI_Array.h
@@ -1,0 +1,63 @@
+﻿// zlib open source license
+//
+// Copyright (c) 2023 to 2026 David Forsgren Piuva
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 
+//    3. This notice may not be removed or altered from any source
+//    distribution.
+
+#ifndef DFPSR_API_ALGORITHM_ARRAY
+#define DFPSR_API_ALGORITHM_ARRAY
+
+#include "../collection/Array.h"
+
+namespace dsr {
+
+// Returns true iff a and b are equal in length and content according to T's equality operator.
+template<typename T>
+bool operator==(const Array<T>& a, const Array<T>& b) {
+	if (a.length() != b.length()) return false;
+	for (intptr_t i = 0; i < a.length(); i++) {
+		if (!(a[i] == b[i])) return false;
+	}
+	return true;
+}
+
+// Returns false iff a and b are equal in length and content according to T's equality operator.
+template<typename T> bool operator!=(const Array<T>& a, const Array<T>& b) { return !(a == b); }
+
+// Printing a generic Array of elements for easy debugging, using the same syntax as when printing List.
+template<typename T>
+String& string_toStreamIndented(String& target, const Array<T>& collection, const ReadableString& indentation) {
+	string_append(target, indentation, U"{\n");
+	intptr_t maxIndex = collection.length() - 1;
+	for (intptr_t i = 0; i <= maxIndex; i++) {
+		string_toStreamIndented(target, collection[i], indentation + U"\t");
+		if (i < maxIndex) {
+			string_append(target, U",");
+		}
+		string_append(target, U"\n");
+	}
+	string_append(target, indentation, U"}");
+	return target;
+}
+
+}
+
+#endif
+

--- a/Source/DFPSR/api/algorithmAPI_Field.h
+++ b/Source/DFPSR/api/algorithmAPI_Field.h
@@ -1,0 +1,75 @@
+﻿// zlib open source license
+//
+// Copyright (c) 2023 to 2026 David Forsgren Piuva
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 
+//    3. This notice may not be removed or altered from any source
+//    distribution.
+
+#ifndef DFPSR_API_FIELD
+#define DFPSR_API_FIELD
+
+#include "../collection/Field.h"
+
+namespace dsr {
+
+// Returns true iff a and b have the same dimensions and content according to T's equality operator.
+template<typename T>
+bool operator==(const Field<T>& a, const Field<T>& b) {
+	if (a.width() != b.width()
+	 || a.height() != b.height()) return false;
+	for (intptr_t y = 0; y < a.height(); y++) {
+		for (intptr_t x = 0; x < a.width(); x++) {
+			if (!(a.unsafe_readAccess(x, y) == b.unsafe_readAccess(x, y))) return false;
+		}
+	}
+	return true;
+}
+
+// Returns false iff a and b have the same dimensions and content according to T's equality operator.
+template<typename T> bool operator!=(const Field<T>& a, const Field<T>& b) { return !(a == b); }
+
+// Printing a generic Field of elements for easy debugging.
+template<typename T>
+String& string_toStreamIndented(String& target, const Field<T>& collection, const ReadableString& indentation) {
+	string_append(target, indentation, U"{\n");
+	intptr_t maxX = collection.width() - 1;
+	intptr_t maxY = collection.height() - 1;
+	for (intptr_t y = 0; y <= maxY; y++) {
+		string_append(target, indentation, U"\t{\n");
+		for (intptr_t x = 0; x <= maxX; x++) {
+			string_toStreamIndented(target, collection.unsafe_readAccess(IVector2D(x, y)), indentation + U"\t\t");
+			if (x < maxX) {
+				string_append(target, U",");
+			}
+			string_append(target, U"\n");
+		}
+		string_append(target, indentation, U"\t}");
+		if (y < maxY) {
+			string_append(target, U",");
+		}
+		string_append(target, U"\n");
+	}
+	string_append(target, indentation, U"}");
+	return target;
+}
+
+}
+
+#endif
+

--- a/Source/DFPSR/api/algorithmAPI_FixedArray.h
+++ b/Source/DFPSR/api/algorithmAPI_FixedArray.h
@@ -1,0 +1,63 @@
+﻿// zlib open source license
+//
+// Copyright (c) 2023 to 2026 David Forsgren Piuva
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 
+//    3. This notice may not be removed or altered from any source
+//    distribution.
+
+#ifndef DFPSR_API_ALGORITHM_FIXED_ARRAY
+#define DFPSR_API_ALGORITHM_FIXED_ARRAY
+
+#include "../collection/FixedArray.h"
+
+namespace dsr {
+
+// Returns true iff a and b are equal in content according to T's equality operator.
+// If the lengths do not match, the call will not be compiled.
+template<typename T, intptr_t LENGTH>
+bool operator==(const FixedArray<T, LENGTH>& a, const FixedArray<T, LENGTH>& b) {
+	for (intptr_t i = 0; i < LENGTH; i++) {
+		if (!(a[i] == b[i])) return false;
+	}
+	return true;
+}
+
+// Returns false iff a and b are equal in content according to T's equality operator.
+template<typename T, intptr_t LENGTH> bool operator!=(const FixedArray<T, LENGTH>& a, const FixedArray<T, LENGTH>& b) { return !(a == b); }
+
+// Printing a generic FixedArray of elements for easy debugging, using the same syntax as when printing List.
+template<typename T, intptr_t LENGTH>
+String& string_toStreamIndented(String& target, const FixedArray<T, LENGTH>& collection, const ReadableString& indentation) {
+	string_append(target, indentation, U"{\n");
+	intptr_t maxIndex = collection.length() - 1;
+	for (intptr_t i = 0; i <= maxIndex; i++) {
+		string_toStreamIndented(target, collection[i], indentation + U"\t");
+		if (i < maxIndex) {
+			string_append(target, U",");
+		}
+		string_append(target, U"\n");
+	}
+	string_append(target, indentation, U"}");
+	return target;
+}
+
+}
+
+#endif
+

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -1,0 +1,66 @@
+﻿// zlib open source license
+//
+// Copyright (c) 2023 to 2026 David Forsgren Piuva
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+//    1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 
+//    2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 
+//    3. This notice may not be removed or altered from any source
+//    distribution.
+
+#ifndef DFPSR_API_ALGORITHM_LIST
+#define DFPSR_API_ALGORITHM_LIST
+
+#include "../collection/List.h"
+
+namespace dsr {
+
+// Returns true iff a and b are equal in length and content according to T's equality operator.
+template<typename T>
+bool operator==(const List<T>& a, const List<T>& b) {
+	if (a.length() != b.length()) return false;
+	for (intptr_t i = 0; i < a.length(); i++) {
+		if (!(a[i] == b[i])) return false;
+	}
+	return true;
+}
+
+// Returns false iff a and b are equal in length and content according to T's equality operator.
+template<typename T> bool operator!=(const List<T>& a, const List<T>& b) { return !(a == b); }
+
+// Printing a generic List of elements for easy debugging.
+//   A new line is used after each element, because the element type might print using multiple lines and the list might be very long.
+//   No new line at the end, because the caller might want to add a comma before breaking the line.
+//   If string_toStreamIndented is defined for lists of a specific element type, this template function will be overridden by the more specific function.
+template<typename T>
+String& string_toStreamIndented(String& target, const List<T>& collection, const ReadableString& indentation) {
+	string_append(target, indentation, U"{\n");
+	intptr_t maxIndex = collection.length() - 1;
+	for (intptr_t i = 0; i <= maxIndex; i++) {
+		string_toStreamIndented(target, collection[i], indentation + U"\t");
+		if (i < maxIndex) {
+			string_append(target, U",");
+		}
+		string_append(target, U"\n");
+	}
+	string_append(target, indentation, U"}");
+	return target;
+}
+
+}
+
+#endif
+

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -30,7 +30,7 @@ namespace dsr {
 
 // Returns true iff a and b are equal in length and content according to T's equality operator.
 template<typename T>
-bool operator==(const List<T>& a, const List<T>& b) {
+static bool operator==(const List<T>& a, const List<T>& b) {
 	if (a.length() != b.length()) return false;
 	for (intptr_t i = 0; i < a.length(); i++) {
 		if (!(a[i] == b[i])) return false;
@@ -39,14 +39,14 @@ bool operator==(const List<T>& a, const List<T>& b) {
 }
 
 // Returns false iff a and b are equal in length and content according to T's equality operator.
-template<typename T> bool operator!=(const List<T>& a, const List<T>& b) { return !(a == b); }
+template<typename T> static bool operator!=(const List<T>& a, const List<T>& b) { return !(a == b); }
 
 // Printing a generic List of elements for easy debugging.
 //   A new line is used after each element, because the element type might print using multiple lines and the list might be very long.
 //   No new line at the end, because the caller might want to add a comma before breaking the line.
 //   If string_toStreamIndented is defined for lists of a specific element type, this template function will be overridden by the more specific function.
 template<typename T>
-String& string_toStreamIndented(String& target, const List<T>& collection, const ReadableString& indentation) {
+static String& string_toStreamIndented(String& target, const List<T>& collection, const ReadableString& indentation) {
 	string_append(target, indentation, U"{\n");
 	intptr_t maxIndex = collection.length() - 1;
 	for (intptr_t i = 0; i <= maxIndex; i++) {
@@ -58,6 +58,285 @@ String& string_toStreamIndented(String& target, const List<T>& collection, const
 	}
 	string_append(target, indentation, U"}");
 	return target;
+}
+
+template <typename OUTPUT_TYPE, typename INPUT_TYPE>
+List<OUTPUT_TYPE> list_map(const List<INPUT_TYPE> &input, const TemporaryCallback<OUTPUT_TYPE(const INPUT_TYPE &element)> &f) {
+	List<OUTPUT_TYPE> result;
+	result.reserve(input.length());
+	for (intptr_t e = 0; e < input.length(); e++) {
+		result.push(f(input[e]));
+	}
+	return result;
+}
+
+// TODO: Implement list_find_all, returning a list with indices to matching elements, using both == and a custom condition.
+
+// Returns an index to the first element in list matching find, or -1 if none could be found.
+template <typename T>
+static intptr_t list_findFirst(const dsr::List<T> &list, const T &find) {
+	for (intptr_t e = 0; e < list.length(); e++) {
+		if (list[e] == find) {
+			return e;
+		}
+	}
+	return -1;
+}
+
+// Returns an index to the first element in list where condition returns true, or -1 if the condition returned false for all elements.
+template <typename T>
+static intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+	for (intptr_t e = 0; e < list.length(); e++) {
+		if (condition(list[e])) {
+			return e;
+		}
+	}
+	return -1;
+}
+
+// Returns an index to the last element in list matching find, or -1 if none could be found.
+template <typename T>
+static intptr_t list_findLast(const dsr::List<T> &list, const T &find) {
+	for (intptr_t e = list.length() - 1; e >= 0; e--) {
+		if (list[e] == find) {
+			return e;
+		}
+	}
+	return -1;
+}
+
+// Returns an index to the last element in list where condition returns true, or -1 if the condition returned false for all elements.
+template <typename T>
+static intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+	for (intptr_t e = list.length() - 1; e >= 0; e--) {
+		if (condition(list[e])) {
+			return e;
+		}
+	}
+	return -1;
+}
+
+// Returns true iff find matches any element in list.
+template <typename T>
+static bool list_elementExists(const dsr::List<T> &list, const T &find) {
+	return list_findFirst(list, find) != -1;
+}
+
+// Returns true iff condition is satisfied for any element in list.
+template <typename T>
+static bool list_elementExists(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+	return list_findFirst(list, condition) != -1;
+}
+
+// Returns true iff find does not exist in list.
+template <typename T>
+static bool list_elementIsMissing(const dsr::List<T> &list, const T &find) {
+	return list_findFirst(list, find) == -1;
+}
+
+// Returns true iff condition is not satisfied for any element in list.
+template <typename T>
+static bool list_elementIsMissing(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+	return list_findFirst(list, condition) == -1;
+}
+
+// Inserts a single element at the end of targetList.
+// Just a simple wrapper over the push operation to allow keeping the style consistent.
+template <typename T>
+inline static void list_insert_last(dsr::List<T> &targetList, const T &element) {
+	targetList.push(element);
+}
+
+// TODO: Take the sorting order as a function argument.
+// TODO: Document
+template <typename T>
+static void list_insert_sorted_ascending(dsr::List<T> &targetList, const T &element) {
+	targetList.push(element);
+	intptr_t at = targetList.length() - 1;
+	while (at > 0 && targetList[at] < targetList[at - 1]) {
+		targetList.swap(at, at - 1);
+		at--;
+	}
+}
+
+// TODO: Document
+template <typename T>
+static void list_append_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+	for (intptr_t e = 0; e < sourceList.length(); e++) {
+		list_insert_last(targetList, sourceList[e]);
+	}
+}
+
+// TODO: Document
+template <typename T>
+static void list_append_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+	for (intptr_t e = 0; e < sourceList.length(); e++) {
+		list_insert_sorted_ascending(targetList, sourceList[e]);
+	}
+}
+
+// TODO: Replace _last and _sorted with a template argument that can be passed from list_insertUnion.
+// TODO: Take a function for equality.
+// Pre-conditions:
+//   All elements in targetList must be unique, or else they will remain duplicated.
+// Pushes element to targetList and return true iff list_elementIsMissing.
+template <typename T>
+static bool list_insertUnique_last(dsr::List<T> &targetList, const T &element) {
+	if (list_elementIsMissing(targetList, element)) {
+		targetList.push(element);
+		return true;
+	} else {
+		return false;
+	}
+}
+
+// TODO: Take functions for both equality and sorting.
+// TODO: Assert that the original list is sorted in debug mode.
+// Pre-conditions:
+//   All elements in targetList must be unique, or else they will remain duplicated.
+//   targetList must be sorted in ascending order.
+// Pushes element to a sorted location in targetList and return true iff list_elementIsMissing.
+// Pre-condition; targetList is sorted according to the < operator when beginning the call.
+// Side-effect: targetList will remain sorted if it was sorted from the start.
+template <typename T>
+static bool list_insertUnique_sorted_ascending(dsr::List<T> &targetList, const T &element) {
+	if (list_elementIsMissing(targetList, element)) {
+		targetList.push(element);
+		intptr_t at = targetList.length() - 1;
+		while (at > 0 && targetList[at] < targetList[at - 1]) {
+			targetList.swap(at, at - 1);
+			at--;
+		}
+		return true;
+	} else {
+		return false;
+	}
+}
+
+// TODO: Having insert union without append is a bit strange, so implement a basic append function as well.
+
+// TODO: Create a varargs version starting with nothing and adding unique elements from all lists before returning by value, so that duplicates in the first list are also reduced.
+// TODO: Take a function for equality.
+// Pre-conditions:
+//   All elements in targetList must be unique, or else they will remain duplicated.
+//   targetList and sourceList may not refer to the same list.
+// Pushes all elements in sourceList that does not already exist in targetList.
+// Returns true iff any element was pushed to targetList.
+template <typename T>
+static bool list_insertUnion_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+	bool result = false;
+	for (intptr_t e = 0; e < sourceList.length(); e++) {
+		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
+		bool newResult = list_insertUnique_last(targetList, sourceList[e]);
+		result = result || newResult;
+	}
+	return result;
+}
+
+// TODO: Create a varargs version starting with nothing and adding unique elements from all lists before returning by value, so that duplicates in the first list are also reduced.
+// TODO: Take functions for both equality and sorting.
+// TODO: Assert that the original list is sorted in debug mode.
+// Pre-conditions:
+//   All elements in targetList must be unique, or else they will remain duplicated.
+//   targetList must be sorted in ascending order.
+//   targetList and sourceList may not refer to the same list.
+// Pushes all elements in sourceList that does not already exist in targetList.
+// Returns true iff any element was pushed to targetList.
+template <typename T>
+static bool list_insertUnion_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+	bool result = false;
+	for (intptr_t e = 0; e < sourceList.length(); e++) {
+		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
+		bool newResult = list_insertUnique_sorted_ascending(targetList, sourceList[e]);
+		result = result || newResult;
+	}
+	return result;
+}
+
+// Helper function for heapSort.
+template <typename T>
+static void impl_list_heapify(dsr::List<T>& targetList, intptr_t n, intptr_t i, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
+	intptr_t largest = i;
+	intptr_t l = 2 * i + 1;
+	intptr_t r = 2 * i + 2;
+	if (l < n && !compare(targetList[l], targetList[largest])) {
+		largest = l;
+	}
+	if (r < n && !compare(targetList[r], targetList[largest])) {
+		largest = r;
+	}
+	if (largest != i) {
+		targetList.swap(i, largest);
+		impl_list_heapify(targetList, n, largest, compare);
+	}
+}
+
+// Apply the heap-sort algorithm to targetList.
+// The compare function should return true when leftSide and rightSide are sorted correctly.
+// Pre-condition:
+//   The compare function must return true when leftSide and rightSide are equal, because elements in the list might be identical.
+// Side-effects:
+//   Overwrites the input with the result, by sorting it in-place.
+//   The elements returned by reference in targetList is a permutation of the original elements,
+//   where each neighboring pair of elements satisfy the compare condition.
+template <typename T>
+static void list_heapSort(List<T>& targetList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
+	intptr_t n = targetList.length();
+	for (intptr_t i = n / 2 - 1; i >= 0; i--) {
+		dsr::impl_list_heapify(targetList, n, i, compare);
+	}
+	for (intptr_t i = n - 1; i > 0; i--) {
+		targetList.swap(0, i);
+		dsr::impl_list_heapify(targetList, i, 0, compare);
+	}
+}
+
+// Using the < operator in T to heap-sort in-place with ascending order.
+//   Useful for basic types where you don't want to write a custom comparison.
+// Side-effects:
+//   Overwrites the input with the result, by sorting it in-place.
+//   The elements returned by reference in targetList is a permutation of the original elements,
+//   where each following element is larger or equal to the previous element.
+template <typename T>
+static void list_heapSort_ascending(List<T>& targetList) {
+	dsr::list_heapSort<T>(targetList, [](const T &leftSide, const T &rightSide) -> bool { return leftSide <= rightSide; });
+}
+
+// Using the > operator in T to heap-sort in-place with descending order.
+//   Useful for basic types where you don't want to write a custom comparison.
+// Side-effects:
+//   Overwrites the input with the result, by sorting it in-place.
+//   The elements returned by reference in targetList is a permutation of the original elements,
+//   where each following element is smaller or equal to the previous element.
+template <typename T>
+static void list_heapSort_descending(List<T>& targetList) {
+	dsr::list_heapSort<T>(targetList, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; });
+}
+
+// TODO: Implement list_isSorted with a custom comparison.
+
+template <typename T>
+static bool list_isSorted_ascending(const List<T>& sourceList) {
+	for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
+		if (sourceList[e] > sourceList[e + 1]) {
+			// Not sorted in ascending order.
+			return false;
+		}
+	}
+	// Sorted in ascending order.
+	return true;
+}
+
+template <typename T>
+static bool list_isSorted_descending(const List<T>& sourceList) {
+	for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
+		if (sourceList[e] < sourceList[e + 1]) {
+			// Not sorted in decending order.
+			return false;
+		}
+	}
+	// Sorted in decending order.
+	return true;
 }
 
 }

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -79,25 +79,91 @@ List<OUTPUT_TYPE> list_map(const List<INPUT_TYPE> &input, const TemporaryCallbac
 	return result;
 }
 
+// action should return true to continue the loop or false when done.
+template <typename T, bool BACKWARD = false>
+static List<intptr_t> list_forAll(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition, const TemporaryCallback<bool(intptr_t index, const T &element)> &action) {
+	List<intptr_t> result;
+	if (BACKWARD) {
+		if (action.hasClosure()) {
+			if (condition.hasClosure()) {
+				// Optimized loop for testing lambda condition.
+				for (intptr_t e = list.length() - 1; e >= 0; e--) {
+					if (condition.callWithClosure(list[e])) {
+						if (!action.callWithClosure(e, list[e])) break;
+					}
+				}
+			} else {
+				// Optimized loop for testing function pointer condition.
+				for (intptr_t e = list.length() - 1; e >= 0; e--) {
+					if (condition.callWithoutClosure(list[e])) {
+						if (!action.callWithClosure(e, list[e])) break;
+					}
+				}
+			}
+		} else {
+			if (condition.hasClosure()) {
+				// Optimized loop for testing lambda condition.
+				for (intptr_t e = list.length() - 1; e >= 0; e--) {
+					if (condition.callWithClosure(list[e])) {
+						if (!action.callWithoutClosure(e, list[e])) break;
+					}
+				}
+			} else {
+				// Optimized loop for testing function pointer condition.
+				for (intptr_t e = list.length() - 1; e >= 0; e--) {
+					if (condition.callWithoutClosure(list[e])) {
+						if (!action.callWithoutClosure(e, list[e])) break;
+					}
+				}
+			}
+		}
+	} else {
+		if (action.hasClosure()) {
+			if (condition.hasClosure()) {
+				// Optimized loop for testing lambda condition.
+				for (intptr_t e = 0; e < list.length(); e++) {
+					if (condition.callWithClosure(list[e])) {
+						if (!action.callWithClosure(e, list[e])) break;
+					}
+				}
+			} else {
+				// Optimized loop for testing function pointer condition.
+				for (intptr_t e = 0; e < list.length(); e++) {
+					if (condition.callWithoutClosure(list[e])) {
+						if (!action.callWithClosure(e, list[e])) break;
+					}
+				}
+			}
+		} else {
+			if (condition.hasClosure()) {
+				// Optimized loop for testing lambda condition.
+				for (intptr_t e = 0; e < list.length(); e++) {
+					if (condition.callWithClosure(list[e])) {
+						if (!action.callWithoutClosure(e, list[e])) break;
+					}
+				}
+			} else {
+				// Optimized loop for testing function pointer condition.
+				for (intptr_t e = 0; e < list.length(); e++) {
+					if (condition.callWithoutClosure(list[e])) {
+						if (!action.callWithoutClosure(e, list[e])) break;
+					}
+				}
+			}
+		}
+	}
+	return result;
+}
+
 // Returns a list of indices to all elements in list where condition returns true, or an empty list if the condition returned false for all elements.
 template <typename T>
 static List<intptr_t> list_findAll(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
 	List<intptr_t> result;
-	if (condition.hasClosure()) {
-		// Optimized loop for testing lambda condition.
-		for (intptr_t e = 0; e < list.length(); e++) {
-			if (condition.callWithClosure(list[e])) {
-				result.push(e);
-			}
-		}
-	} else {
-		// Optimized loop for testing function pointer condition.
-		for (intptr_t e = 0; e < list.length(); e++) {
-			if (condition.callWithoutClosure(list[e])) {
-				result.push(e);
-			}
-		}
-	}
+	// Ascending loop
+	list_forAll<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
+		result.push(index); // Push the element's index to the list.
+		return true; // Keep iterating over the list.
+	});
 	return result;
 }
 
@@ -112,12 +178,13 @@ static List<intptr_t> list_findAll(const dsr::List<T> &list, const T &find) {
 // Returns an index to the first element in list where condition returns true, or -1 if the condition returned false for all elements.
 template <typename T>
 static intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
-	for (intptr_t e = 0; e < list.length(); e++) {
-		if (condition(list[e])) {
-			return e;
-		}
-	}
-	return -1;
+	intptr_t result = -1;
+	// Ascending loop
+	list_forAll<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
+		result = index; // Take the index as the result.
+		return false; // We are done iterating over the list.
+	});
+	return result;
 }
 
 // Returns an index to the first element in list matching find, or -1 if none could be found.
@@ -131,12 +198,13 @@ static intptr_t list_findFirst(const dsr::List<T> &list, const T &find) {
 // Returns an index to the last element in list matching find, or -1 if none could be found.
 template <typename T>
 static intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
-	for (intptr_t e = list.length() - 1; e >= 0; e--) {
-		if (condition(list[e])) {
-			return e;
-		}
-	}
-	return -1;
+	intptr_t result = -1;
+	// Descending loop
+	list_forAll<T, true>(list, condition, [&result](intptr_t index, const T &element) -> bool {
+		result = index; // Take the index as the result.
+		return false; // We are done iterating over the list.
+	});
+	return result;
 }
 
 // Returns an index to the last element in list where condition returns true, or -1 if the condition returned false for all elements.

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -261,6 +261,9 @@ static void list_insert_sorted_ascending(dsr::List<T> &targetList, const T &elem
 // TODO: Document
 template <typename T>
 static void list_append_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+	// Reserve enough space for all the new elements.
+	targetList.reserve(targetList.length() + sourceList.length());
+	// Place the elements at the end.
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		list_insert_last(targetList, sourceList[e]);
 	}
@@ -269,6 +272,9 @@ static void list_append_last(dsr::List<T> &targetList, const dsr::List<T> &sourc
 // TODO: Document
 template <typename T>
 static void list_append_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+	// Reserve enough space for all the new elements.
+	targetList.reserve(targetList.length() + sourceList.length());
+	// Insert the elements.
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		list_insert_sorted_ascending(targetList, sourceList[e]);
 	}

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -504,8 +504,6 @@ static inline intptr_t list_insert_unique_sorted_descending(
 	return list_insert_unique_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; }, compareEqual);
 }
 
-// TODO: Create a varargs union function, starting with nothing and adding unique elements from all lists before returning by value, so that duplicates in the first list are also reduced.
-
 // Pre-conditions:
 //   * All elements in targetList must be unique, or else they will remain duplicated.
 //   * targetList and sourceList may not refer to the same list.

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -386,13 +386,13 @@ static inline void list_append_sorted_descending(dsr::List<T> &targetList, const
 	}
 }
 
-// TODO: Replace _last and _sorted with a template argument that can be passed from list_appendUnique.
+// TODO: Replace _last and _sorted with a template argument that can be passed from list_append_unique.
 // TODO: Take a function for equality.
 // Pre-conditions:
 //   All elements in targetList must be unique, or else they will remain duplicated.
 // Pushes element to targetList and return true iff list_elementIsMissing.
 template <typename T>
-static inline bool list_insertUnique_last(dsr::List<T> &targetList, const T &element) {
+static inline bool list_insert_unique_last(dsr::List<T> &targetList, const T &element) {
 	if (list_elementIsMissing(targetList, element)) {
 		targetList.push(element);
 		return true;
@@ -410,7 +410,7 @@ static inline bool list_insertUnique_last(dsr::List<T> &targetList, const T &ele
 // Pre-condition; targetList is sorted according to the < operator when beginning the call.
 // Side-effect: targetList will remain sorted if it was sorted from the start.
 template <typename T>
-static inline bool list_insertUnique_sorted_ascending(dsr::List<T> &targetList, const T &element) {
+static inline bool list_insert_unique_sorted_ascending(dsr::List<T> &targetList, const T &element) {
 	if (list_elementIsMissing(targetList, element)) {
 		targetList.push(element);
 		intptr_t at = targetList.length() - 1;
@@ -434,11 +434,11 @@ static inline bool list_insertUnique_sorted_ascending(dsr::List<T> &targetList, 
 // Pushes all elements in sourceList that does not already exist in targetList.
 // Returns true iff any element was pushed to targetList.
 template <typename T>
-static inline bool list_appendUnique_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+static inline bool list_append_unique_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
 	bool result = false;
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
-		bool newResult = list_insertUnique_last(targetList, sourceList[e]);
+		bool newResult = list_insert_unique_last(targetList, sourceList[e]);
 		result = result || newResult;
 	}
 	return result;
@@ -454,11 +454,11 @@ static inline bool list_appendUnique_last(dsr::List<T> &targetList, const dsr::L
 // Pushes all elements in sourceList that does not already exist in targetList.
 // Returns true iff any element was pushed to targetList.
 template <typename T>
-static inline bool list_appendUnique_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+static inline bool list_append_unique_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
 	bool result = false;
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
-		bool newResult = list_insertUnique_sorted_ascending(targetList, sourceList[e]);
+		bool newResult = list_insert_unique_sorted_ascending(targetList, sourceList[e]);
 		result = result || newResult;
 	}
 	return result;

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -249,10 +249,24 @@ inline static void list_insert_last(dsr::List<T> &targetList, const T &element) 
 // Post-condition: Returns true iff the list is sorted according to compare, meaning that each neigoboring pair of elements in sourceList satisfies the comparison in the compare function.
 template <typename T>
 static bool list_isSorted(const List<T>& sourceList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
-	for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
-		if (!compare(sourceList[e], sourceList[e + 1])) {
-			// Not sorted according to compare.
-			return false;
+	if (compare.hasClosure()) {
+		// Optimized loop for comparing with lambda,
+		//   for when you have to follow indices through captured collection to see the real meaning behind an index,
+		//   or just use a lambda with an empty closure for the convenience.
+		for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
+			if (!compare.callWithClosure(sourceList[e], sourceList[e + 1])) {
+				// Not sorted according to compare.
+				return false;
+			}
+		}
+	} else {
+		// Optimized loop for comparing with function pointer,
+		//   for when a comparison can be done directly on the elements.
+		for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
+			if (!compare.callWithoutClosure(sourceList[e], sourceList[e + 1])) {
+				// Not sorted according to compare.
+				return false;
+			}
 		}
 	}
 	// Sorted according to compare.

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -157,7 +157,7 @@ static List<intptr_t> list_forAll(const dsr::List<T> &list, const TemporaryCallb
 
 // Returns a list of indices to all elements in list where condition returns true, or an empty list if the condition returned false for all elements.
 template <typename T>
-static List<intptr_t> list_findAll(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+static inline List<intptr_t> list_findAll(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
 	List<intptr_t> result;
 	// Ascending loop
 	list_forAll<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
@@ -169,7 +169,7 @@ static List<intptr_t> list_findAll(const dsr::List<T> &list, const TemporaryCall
 
 // Returns a list of indices to all elements in list matching, or an empty list if there is no match.
 template <typename T>
-static List<intptr_t> list_findAll(const dsr::List<T> &list, const T &find) {
+static inline List<intptr_t> list_findAll(const dsr::List<T> &list, const T &find) {
 	return list_findAll<T>(list, [find](const T &element) -> bool {
 		return element == find;
 	});
@@ -177,7 +177,7 @@ static List<intptr_t> list_findAll(const dsr::List<T> &list, const T &find) {
 
 // Returns an index to the first element in list where condition returns true, or -1 if the condition returned false for all elements.
 template <typename T>
-static intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+static inline intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
 	intptr_t result = -1;
 	// Ascending loop
 	list_forAll<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
@@ -189,7 +189,7 @@ static intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryCallback
 
 // Returns an index to the first element in list matching find, or -1 if none could be found.
 template <typename T>
-static intptr_t list_findFirst(const dsr::List<T> &list, const T &find) {
+static inline intptr_t list_findFirst(const dsr::List<T> &list, const T &find) {
 	return list_findFirst<T>(list, [find](const T &element) -> bool {
 		return element == find;
 	});
@@ -197,7 +197,7 @@ static intptr_t list_findFirst(const dsr::List<T> &list, const T &find) {
 
 // Returns an index to the last element in list matching find, or -1 if none could be found.
 template <typename T>
-static intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+static inline intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
 	intptr_t result = -1;
 	// Descending loop
 	list_forAll<T, true>(list, condition, [&result](intptr_t index, const T &element) -> bool {
@@ -207,43 +207,36 @@ static intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<
 	return result;
 }
 
-// Returns an index to the last element in list where condition returns true, or -1 if the condition returned false for all elements.
+// Post-condition: Returns an index to the last element in list where condition returns true, or -1 if the condition returned false for all elements.
 template <typename T>
-static intptr_t list_findLast(const dsr::List<T> &list, const T &find) {
+static inline intptr_t list_findLast(const dsr::List<T> &list, const T &find) {
 	return list_findLast<T>(list, [find](const T &element) -> bool {
 		return element == find;
 	});
 }
 
-// Returns true iff find matches any element in list.
+// Post-condition: Returns true iff find matches any element in list.
 template <typename T>
-static bool list_elementExists(const dsr::List<T> &list, const T &find) {
+static inline bool list_elementExists(const dsr::List<T> &list, const T &find) {
 	return list_findFirst(list, find) != -1;
 }
 
-// Returns true iff condition is satisfied for any element in list.
+// Post-condition: Returns true iff condition is satisfied for any element in list.
 template <typename T>
-static bool list_elementExists(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+static inline bool list_elementExists(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
 	return list_findFirst(list, condition) != -1;
 }
 
-// Returns true iff find does not exist in list.
+// Post-condition: Returns true iff find does not exist in list.
 template <typename T>
-static bool list_elementIsMissing(const dsr::List<T> &list, const T &find) {
+static inline bool list_elementIsMissing(const dsr::List<T> &list, const T &find) {
 	return list_findFirst(list, find) == -1;
 }
 
-// Returns true iff condition is not satisfied for any element in list.
+// Post-condition: Returns true iff condition is not satisfied for any element in list.
 template <typename T>
-static bool list_elementIsMissing(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+static inline bool list_elementIsMissing(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
 	return list_findFirst(list, condition) == -1;
-}
-
-// Inserts a single element at the end of targetList.
-// Just a simple wrapper over the push operation to allow keeping the style consistent.
-template <typename T>
-inline static void list_insert_last(dsr::List<T> &targetList, const T &element) {
-	targetList.push(element);
 }
 
 // Post-condition: Returns true iff the list is sorted according to compare, meaning that each neigoboring pair of elements in sourceList satisfies the comparison in the compare function.
@@ -276,32 +269,79 @@ static bool list_isSorted(const List<T>& sourceList, const TemporaryCallback<boo
 // If you have a default way of sorting T, you can just define comparison operators for the type to avoid referring to a custom comparison function every time.
 // Post-condition: Returns true iff the list is sorted in ascending order according to T's <= operator, meaning that sourceList[n] <= sourceList[n + 1] for all neighboring elements.
 template <typename T>
-static bool list_isSorted_ascending(const List<T>& sourceList) {
+static inline bool list_isSorted_ascending(const List<T>& sourceList) {
 	return list_isSorted<T>(sourceList, [](const T &leftSide, const T &rightSide) -> bool { return leftSide <= rightSide; });
 }
 
 // If you have a default way of sorting T, you can just define comparison operators for the type to avoid referring to a custom comparison function every time.
 // Post-condition: Returns true iff the list is sorted in descending order according to T's >= operator, meaning that sourceList[n] >= sourceList[n + 1] for all neighboring elements.
 template <typename T>
-static bool list_isSorted_descending(const List<T>& sourceList) {
+static inline bool list_isSorted_descending(const List<T>& sourceList) {
 	return list_isSorted<T>(sourceList, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; });
 }
 
-// TODO: Take the sorting order as a function argument.
-// TODO: Document
+// Insert an element into an unsorted list.
+// Side-effect:
+//   * targetList expands to include a copy of the new element at the end.
 template <typename T>
-static void list_insert_sorted_ascending(dsr::List<T> &targetList, const T &element) {
+static inline void list_insert_last(dsr::List<T> &targetList, const T &element) {
+	targetList.push(element);
+}
+
+// Insert an element into a sorted list.
+// The insertion is stable, so no pre-existing equal elements will change order between each other.
+//   If targetList already contains any elements that are considered equal to element, the new element will be placed behind all of them.
+// Pre-condition:
+//   * targetList must be sorted according to compare, so that list_isSorted(targetList, compare) would return true.
+// Side-effect:
+//   * targetList expands to include a copy of the new element at a sorted location.
+//   * targetList remains sorted according to compare, so that list_isSorted(targetList, compare) will still return true.
+template <typename T>
+static void list_insert_sorted(dsr::List<T> &targetList, const T &element, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
+	#ifndef NDEBUG
+		if (!list_isSorted(targetList, compare)) {
+			throwError(U"Tried to call list_insert_sorted with a target list that was not already sorted!\n");
+		}
+	#endif
 	targetList.push(element);
 	intptr_t at = targetList.length() - 1;
-	while (at > 0 && targetList[at] < targetList[at - 1]) {
+	while (at > 0 && !compare(targetList[at - 1], targetList[at])) {
 		targetList.swap(at, at - 1);
 		at--;
 	}
 }
 
-// TODO: Document
+// Insert an element into a sorted list.
+// The insertion is stable, so no pre-existing equal elements will change order between each other.
+//   If targetList already contains any elements that are considered equal to element, the new element will be placed behind all of them.
+// Pre-condition:
+//   targetList must be sorted according to T's <= operator, so that list_isSorted_ascending(targetList) would return true.
+// Side-effect:
+//   * targetList expands to include a copy of the new element at a sorted location.
+//   * targetList remains sorted according to T's <= operator, so that list_isSorted_ascending(targetList) will still return true.
 template <typename T>
-static void list_append_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+static inline void list_insert_sorted_ascending(dsr::List<T> &targetList, const T &element) {
+	list_insert_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide <= rightSide; });
+}
+
+// Insert an element into a sorted list.
+// The insertion is stable, so no pre-existing equal elements will change order between each other.
+//   If targetList already contains any elements that are considered equal to element, the new element will be placed behind all of them.
+// Pre-condition:
+//   targetList must be sorted according to T's >= operator, so that list_isSorted_descending(targetList) would return true.
+// Side-effect:
+//   * targetList expands to include a copy of the new element at a sorted location.
+//   * targetList remains sorted according to T's >= operator, so that list_isSorted_descending(targetList) will still return true.
+template <typename T>
+static inline void list_insert_sorted_descending(dsr::List<T> &targetList, const T &element) {
+	list_insert_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; });
+}
+
+// Insert copies of the elements from sourceList into the end of targetList.
+// Side-effect:
+//   * targetList expands to include a copy of all elements in sourceList.
+template <typename T>
+static inline void list_append_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
 	// Reserve enough space for all the new elements.
 	targetList.reserve(targetList.length() + sourceList.length());
 	// Place the elements at the end.
@@ -310,14 +350,39 @@ static void list_append_last(dsr::List<T> &targetList, const dsr::List<T> &sourc
 	}
 }
 
-// TODO: Document
+// Convenient wrapper for calling list_insert_sorted for all elements in sourceList.
+//   Each element is inserted individually to find its sorted location within targetList.
 template <typename T>
-static void list_append_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+static inline void list_append_sorted(dsr::List<T> &targetList, const dsr::List<T> &sourceList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
 	// Reserve enough space for all the new elements.
 	targetList.reserve(targetList.length() + sourceList.length());
 	// Insert the elements.
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
-		list_insert_sorted_ascending(targetList, sourceList[e]);
+		list_insert_sorted<T>(targetList, sourceList[e], compare);
+	}
+}
+
+// Convenient wrapper for calling list_insert_sorted_ascending for all elements in sourceList.
+//   Each element is inserted individually to find its sorted location within targetList.
+template <typename T>
+static inline void list_append_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+	// Reserve enough space for all the new elements.
+	targetList.reserve(targetList.length() + sourceList.length());
+	// Insert the elements.
+	for (intptr_t e = 0; e < sourceList.length(); e++) {
+		list_insert_sorted_ascending<T>(targetList, sourceList[e]);
+	}
+}
+
+// Convenient wrapper for calling list_insert_sorted_descending for all elements in sourceList.
+//   Each element is inserted individually to find its sorted location within targetList.
+template <typename T>
+static inline void list_append_sorted_descending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+	// Reserve enough space for all the new elements.
+	targetList.reserve(targetList.length() + sourceList.length());
+	// Insert the elements.
+	for (intptr_t e = 0; e < sourceList.length(); e++) {
+		list_insert_sorted_descending<T>(targetList, sourceList[e]);
 	}
 }
 
@@ -327,7 +392,7 @@ static void list_append_sorted_ascending(dsr::List<T> &targetList, const dsr::Li
 //   All elements in targetList must be unique, or else they will remain duplicated.
 // Pushes element to targetList and return true iff list_elementIsMissing.
 template <typename T>
-static bool list_insertUnique_last(dsr::List<T> &targetList, const T &element) {
+static inline bool list_insertUnique_last(dsr::List<T> &targetList, const T &element) {
 	if (list_elementIsMissing(targetList, element)) {
 		targetList.push(element);
 		return true;
@@ -345,7 +410,7 @@ static bool list_insertUnique_last(dsr::List<T> &targetList, const T &element) {
 // Pre-condition; targetList is sorted according to the < operator when beginning the call.
 // Side-effect: targetList will remain sorted if it was sorted from the start.
 template <typename T>
-static bool list_insertUnique_sorted_ascending(dsr::List<T> &targetList, const T &element) {
+static inline bool list_insertUnique_sorted_ascending(dsr::List<T> &targetList, const T &element) {
 	if (list_elementIsMissing(targetList, element)) {
 		targetList.push(element);
 		intptr_t at = targetList.length() - 1;
@@ -369,7 +434,7 @@ static bool list_insertUnique_sorted_ascending(dsr::List<T> &targetList, const T
 // Pushes all elements in sourceList that does not already exist in targetList.
 // Returns true iff any element was pushed to targetList.
 template <typename T>
-static bool list_appendUnique_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+static inline bool list_appendUnique_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
 	bool result = false;
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
@@ -389,7 +454,7 @@ static bool list_appendUnique_last(dsr::List<T> &targetList, const dsr::List<T> 
 // Pushes all elements in sourceList that does not already exist in targetList.
 // Returns true iff any element was pushed to targetList.
 template <typename T>
-static bool list_appendUnique_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+static inline bool list_appendUnique_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
 	bool result = false;
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		// Must store the result in a new variable to avoid lazy evaluation with side-effects.

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -79,23 +79,32 @@ List<OUTPUT_TYPE> list_map(const List<INPUT_TYPE> &input, const TemporaryCallbac
 	return result;
 }
 
+// Side-effects:
+//   * Execute action on each element in list that satisfies condition.
+// Let BACKWARD be false to loop forwards from 0 to length - 1.
+// Let BACKWARD be true to loop backwards from length - 1 to 0.
+// condition should return true iff the given element should call action,
 // action should return true to continue the loop or false when done.
 template <typename T, bool BACKWARD = false>
-static List<intptr_t> list_forAll(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition, const TemporaryCallback<bool(intptr_t index, const T &element)> &action) {
+static List<intptr_t> list_forAll(
+  const dsr::List<T> &list,
+  const TemporaryCallback<bool(intptr_t index, const T &element)> &condition,
+  const TemporaryCallback<bool(intptr_t index, const T &element)> &action
+) {
 	List<intptr_t> result;
 	if (BACKWARD) {
 		if (action.hasClosure()) {
 			if (condition.hasClosure()) {
 				// Optimized loop for testing lambda condition.
 				for (intptr_t e = list.length() - 1; e >= 0; e--) {
-					if (condition.callWithClosure(list[e])) {
+					if (condition.callWithClosure(e, list[e])) {
 						if (!action.callWithClosure(e, list[e])) break;
 					}
 				}
 			} else {
 				// Optimized loop for testing function pointer condition.
 				for (intptr_t e = list.length() - 1; e >= 0; e--) {
-					if (condition.callWithoutClosure(list[e])) {
+					if (condition.callWithoutClosure(e, list[e])) {
 						if (!action.callWithClosure(e, list[e])) break;
 					}
 				}
@@ -104,14 +113,14 @@ static List<intptr_t> list_forAll(const dsr::List<T> &list, const TemporaryCallb
 			if (condition.hasClosure()) {
 				// Optimized loop for testing lambda condition.
 				for (intptr_t e = list.length() - 1; e >= 0; e--) {
-					if (condition.callWithClosure(list[e])) {
+					if (condition.callWithClosure(e, list[e])) {
 						if (!action.callWithoutClosure(e, list[e])) break;
 					}
 				}
 			} else {
 				// Optimized loop for testing function pointer condition.
 				for (intptr_t e = list.length() - 1; e >= 0; e--) {
-					if (condition.callWithoutClosure(list[e])) {
+					if (condition.callWithoutClosure(e, list[e])) {
 						if (!action.callWithoutClosure(e, list[e])) break;
 					}
 				}
@@ -122,14 +131,14 @@ static List<intptr_t> list_forAll(const dsr::List<T> &list, const TemporaryCallb
 			if (condition.hasClosure()) {
 				// Optimized loop for testing lambda condition.
 				for (intptr_t e = 0; e < list.length(); e++) {
-					if (condition.callWithClosure(list[e])) {
+					if (condition.callWithClosure(e, list[e])) {
 						if (!action.callWithClosure(e, list[e])) break;
 					}
 				}
 			} else {
 				// Optimized loop for testing function pointer condition.
 				for (intptr_t e = 0; e < list.length(); e++) {
-					if (condition.callWithoutClosure(list[e])) {
+					if (condition.callWithoutClosure(e, list[e])) {
 						if (!action.callWithClosure(e, list[e])) break;
 					}
 				}
@@ -138,14 +147,14 @@ static List<intptr_t> list_forAll(const dsr::List<T> &list, const TemporaryCallb
 			if (condition.hasClosure()) {
 				// Optimized loop for testing lambda condition.
 				for (intptr_t e = 0; e < list.length(); e++) {
-					if (condition.callWithClosure(list[e])) {
+					if (condition.callWithClosure(e, list[e])) {
 						if (!action.callWithoutClosure(e, list[e])) break;
 					}
 				}
 			} else {
 				// Optimized loop for testing function pointer condition.
 				for (intptr_t e = 0; e < list.length(); e++) {
-					if (condition.callWithoutClosure(list[e])) {
+					if (condition.callWithoutClosure(e, list[e])) {
 						if (!action.callWithoutClosure(e, list[e])) break;
 					}
 				}
@@ -155,9 +164,10 @@ static List<intptr_t> list_forAll(const dsr::List<T> &list, const TemporaryCallb
 	return result;
 }
 
-// Returns a list of indices to all elements in list where condition returns true, or an empty list if the condition returned false for all elements.
+// Post-conditions:
+//   * Returns a list of indices to all elements in list where condition returns true, or an empty list if the condition returned false for all elements.
 template <typename T>
-static inline List<intptr_t> list_findAll(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+static inline List<intptr_t> list_findAll(const dsr::List<T> &list, const TemporaryCallback<bool(intptr_t index, const T &element)> &condition) {
 	List<intptr_t> result;
 	// Ascending loop
 	list_forAll<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
@@ -167,17 +177,19 @@ static inline List<intptr_t> list_findAll(const dsr::List<T> &list, const Tempor
 	return result;
 }
 
-// Returns a list of indices to all elements in list matching, or an empty list if there is no match.
+// Post-conditions:
+//   * Returns a list of indices to all elements in list matching, or an empty list if there is no match.
 template <typename T>
 static inline List<intptr_t> list_findAll(const dsr::List<T> &list, const T &find) {
-	return list_findAll<T>(list, [find](const T &element) -> bool {
+	return list_findAll<T>(list, [&find](intptr_t index, const T &element) -> bool {
 		return element == find;
 	});
 }
 
-// Returns an index to the first element in list where condition returns true, or -1 if the condition returned false for all elements.
+// Post-conditions:
+//   * Returns an index to the first element in list satisfying condition, or -1 if none could be found.
 template <typename T>
-static inline intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+static inline intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryCallback<bool(intptr_t index, const T &element)> &condition) {
 	intptr_t result = -1;
 	// Ascending loop
 	list_forAll<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
@@ -187,17 +199,19 @@ static inline intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryC
 	return result;
 }
 
-// Returns an index to the first element in list matching find, or -1 if none could be found.
+// Post-conditions:
+//   * Returns an index to the first element in list matching find according to T's == operator, or -1 if none could be found.
 template <typename T>
 static inline intptr_t list_findFirst(const dsr::List<T> &list, const T &find) {
-	return list_findFirst<T>(list, [find](const T &element) -> bool {
+	return list_findFirst<T>(list, [&find](intptr_t index, const T &element) -> bool {
 		return element == find;
 	});
 }
 
-// Returns an index to the last element in list matching find, or -1 if none could be found.
+// Post-conditions:
+//   * Returns an index to the last element in list satisfying condition, or -1 if none could be found.
 template <typename T>
-static inline intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+static inline intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<bool(intptr_t index, const T &element)> &condition) {
 	intptr_t result = -1;
 	// Descending loop
 	list_forAll<T, true>(list, condition, [&result](intptr_t index, const T &element) -> bool {
@@ -207,48 +221,49 @@ static inline intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCa
 	return result;
 }
 
-// Post-condition: Returns an index to the last element in list where condition returns true, or -1 if the condition returned false for all elements.
+// Post-conditions:
+//   * Returns an index to the last element in list matching find according to T's == operator, or -1 if none could be found.
 template <typename T>
 static inline intptr_t list_findLast(const dsr::List<T> &list, const T &find) {
-	return list_findLast<T>(list, [find](const T &element) -> bool {
+	return list_findLast<T>(list, [&find](intptr_t index, const T &element) -> bool {
 		return element == find;
 	});
 }
 
-// Post-condition: Returns true iff find matches any element in list.
+// Post-condition: Returns true iff condition is satisfied for any element in list.
+template <typename T>
+static inline bool list_elementExists(const dsr::List<T> &list, const TemporaryCallback<bool(intptr_t index, const T &element)> &condition) {
+	return list_findFirst(list, condition) != -1;
+}
+
+// Post-condition: Returns true iff find matches any element in list according to T's == operator.
 template <typename T>
 static inline bool list_elementExists(const dsr::List<T> &list, const T &find) {
 	return list_findFirst(list, find) != -1;
 }
 
-// Post-condition: Returns true iff condition is satisfied for any element in list.
+// Post-condition: Returns true iff condition is not satisfied for any element in list.
 template <typename T>
-static inline bool list_elementExists(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
-	return list_findFirst(list, condition) != -1;
+static inline bool list_elementIsMissing(const dsr::List<T> &list, const TemporaryCallback<bool(intptr_t index, const T &element)> &condition) {
+	return list_findFirst(list, condition) == -1;
 }
 
-// Post-condition: Returns true iff find does not exist in list.
+// Post-condition: Returns true iff find does not exist in list according to T's == operator.
 template <typename T>
 static inline bool list_elementIsMissing(const dsr::List<T> &list, const T &find) {
 	return list_findFirst(list, find) == -1;
 }
 
-// Post-condition: Returns true iff condition is not satisfied for any element in list.
+// Post-condition: Returns true iff the list is sorted according to sortCompare, meaning that each neigoboring pair of elements in sourceList satisfies the comparison in the sortCompare function.
 template <typename T>
-static inline bool list_elementIsMissing(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
-	return list_findFirst(list, condition) == -1;
-}
-
-// Post-condition: Returns true iff the list is sorted according to compare, meaning that each neigoboring pair of elements in sourceList satisfies the comparison in the compare function.
-template <typename T>
-static bool list_isSorted(const List<T>& sourceList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
-	if (compare.hasClosure()) {
+static bool list_isSorted(const List<T>& sourceList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &sortCompare) {
+	if (sortCompare.hasClosure()) {
 		// Optimized loop for comparing with lambda,
 		//   for when you have to follow indices through captured collection to see the real meaning behind an index,
 		//   or just use a lambda with an empty closure for the convenience.
 		for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
-			if (!compare.callWithClosure(sourceList[e], sourceList[e + 1])) {
-				// Not sorted according to compare.
+			if (!sortCompare.callWithClosure(sourceList[e], sourceList[e + 1])) {
+				// Not sorted according to sortCompare.
 				return false;
 			}
 		}
@@ -256,13 +271,13 @@ static bool list_isSorted(const List<T>& sourceList, const TemporaryCallback<boo
 		// Optimized loop for comparing with function pointer,
 		//   for when a comparison can be done directly on the elements.
 		for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
-			if (!compare.callWithoutClosure(sourceList[e], sourceList[e + 1])) {
-				// Not sorted according to compare.
+			if (!sortCompare.callWithoutClosure(sourceList[e], sourceList[e + 1])) {
+				// Not sorted according to sortCompare.
 				return false;
 			}
 		}
 	}
-	// Sorted according to compare.
+	// Sorted according to sortCompare.
 	return true;
 }
 
@@ -280,38 +295,44 @@ static inline bool list_isSorted_descending(const List<T>& sourceList) {
 	return list_isSorted<T>(sourceList, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; });
 }
 
-// Insert an element into an unsorted list.
+// Insert an element into an unsorted list and return the element's new index.
+// For consistency with the insert_unique functions that do not always push something to refer to, there is no version returning by reference.
 // Side-effect:
 //   * targetList expands to include a copy of the new element at the end.
 template <typename T>
-static inline void list_insert_last(dsr::List<T> &targetList, const T &element) {
-	targetList.push(element);
+static inline intptr_t list_insert_last(dsr::List<T> &targetList, const T &element) {
+	return targetList.pushGetIndex(element);
 }
 
-// Insert an element into a sorted list.
+// Insert an element into a sorted list and return its new index.
+// For consistency with the insert_unique functions that do not always push something to refer to, there is no version returning by reference.
 // The insertion is stable, so no pre-existing equal elements will change order between each other.
 //   If targetList already contains any elements that are considered equal to element, the new element will be placed behind all of them.
 // Pre-condition:
-//   * targetList must be sorted according to compare, so that list_isSorted(targetList, compare) would return true.
+//   * targetList must be sorted according to sortCompare, so that list_isSorted(targetList, sortCompare) would return true.
 // Side-effect:
 //   * targetList expands to include a copy of the new element at a sorted location.
-//   * targetList remains sorted according to compare, so that list_isSorted(targetList, compare) will still return true.
+//   * targetList remains sorted according to sortCompare, so that list_isSorted(targetList, sortCompare) will still return true.
+// Post-condition:
+//   * Returns the inserted element's new index in targetList.
 template <typename T>
-static void list_insert_sorted(dsr::List<T> &targetList, const T &element, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
+static intptr_t list_insert_sorted(dsr::List<T> &targetList, const T &element, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &sortCompare) {
 	#ifndef NDEBUG
-		if (!list_isSorted(targetList, compare)) {
+		if (!list_isSorted(targetList, sortCompare)) {
 			throwError(U"Tried to call list_insert_sorted with a target list that was not already sorted!\n");
 		}
 	#endif
 	targetList.push(element);
 	intptr_t at = targetList.length() - 1;
-	while (at > 0 && !compare(targetList[at - 1], targetList[at])) {
-		targetList.swap(at, at - 1);
+	while (at > 0 && !sortCompare(targetList[at - 1], targetList[at])) {
+		targetList.swap(at - 1, at);
 		at--;
 	}
+	return at;
 }
 
-// Insert an element into a sorted list.
+// Insert an element into a sorted list and return its new index.
+// For consistency with the insert_unique functions that do not always push something to refer to, there is no version returning by reference.
 // The insertion is stable, so no pre-existing equal elements will change order between each other.
 //   If targetList already contains any elements that are considered equal to element, the new element will be placed behind all of them.
 // Pre-condition:
@@ -319,12 +340,15 @@ static void list_insert_sorted(dsr::List<T> &targetList, const T &element, const
 // Side-effect:
 //   * targetList expands to include a copy of the new element at a sorted location.
 //   * targetList remains sorted according to T's <= operator, so that list_isSorted_ascending(targetList) will still return true.
+// Post-condition:
+//   * Returns the inserted element's new index in targetList.
 template <typename T>
-static inline void list_insert_sorted_ascending(dsr::List<T> &targetList, const T &element) {
-	list_insert_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide <= rightSide; });
+static inline intptr_t list_insert_sorted_ascending(dsr::List<T> &targetList, const T &element) {
+	return list_insert_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide <= rightSide; });
 }
 
-// Insert an element into a sorted list.
+// Insert an element into a sorted list and return its new index.
+// For consistency with the insert_unique functions that do not always push something to refer to, there is no version returning by reference.
 // The insertion is stable, so no pre-existing equal elements will change order between each other.
 //   If targetList already contains any elements that are considered equal to element, the new element will be placed behind all of them.
 // Pre-condition:
@@ -332,9 +356,11 @@ static inline void list_insert_sorted_ascending(dsr::List<T> &targetList, const 
 // Side-effect:
 //   * targetList expands to include a copy of the new element at a sorted location.
 //   * targetList remains sorted according to T's >= operator, so that list_isSorted_descending(targetList) will still return true.
+// Post-condition:
+//   * Returns the inserted element's new index in targetList.
 template <typename T>
-static inline void list_insert_sorted_descending(dsr::List<T> &targetList, const T &element) {
-	list_insert_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; });
+static inline intptr_t list_insert_sorted_descending(dsr::List<T> &targetList, const T &element) {
+	return list_insert_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; });
 }
 
 // Insert copies of the elements from sourceList into the end of targetList.
@@ -352,18 +378,20 @@ static inline void list_append_last(dsr::List<T> &targetList, const dsr::List<T>
 
 // Convenient wrapper for calling list_insert_sorted for all elements in sourceList.
 //   Each element is inserted individually to find its sorted location within targetList.
+// Call list_insert_sorted directly if you need to know the new indices from its result.
 template <typename T>
-static inline void list_append_sorted(dsr::List<T> &targetList, const dsr::List<T> &sourceList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
+static inline void list_append_sorted(dsr::List<T> &targetList, const dsr::List<T> &sourceList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &sortCompare) {
 	// Reserve enough space for all the new elements.
 	targetList.reserve(targetList.length() + sourceList.length());
 	// Insert the elements.
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
-		list_insert_sorted<T>(targetList, sourceList[e], compare);
+		list_insert_sorted<T>(targetList, sourceList[e], sortCompare);
 	}
 }
 
 // Convenient wrapper for calling list_insert_sorted_ascending for all elements in sourceList.
 //   Each element is inserted individually to find its sorted location within targetList.
+// Call list_insert_sorted_ascending directly if you need to know the new indices from its result.
 template <typename T>
 static inline void list_append_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
 	// Reserve enough space for all the new elements.
@@ -376,6 +404,7 @@ static inline void list_append_sorted_ascending(dsr::List<T> &targetList, const 
 
 // Convenient wrapper for calling list_insert_sorted_descending for all elements in sourceList.
 //   Each element is inserted individually to find its sorted location within targetList.
+// Call list_insert_sorted_descending directly if you need to know the new indices from its result.
 template <typename T>
 static inline void list_append_sorted_descending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
 	// Reserve enough space for all the new elements.
@@ -386,51 +415,101 @@ static inline void list_append_sorted_descending(dsr::List<T> &targetList, const
 	}
 }
 
-// TODO: Replace _last and _sorted with a template argument that can be passed from list_append_unique.
-// TODO: Take a function for equality.
+// Only inserting element when element does not have an equal in targetList.
 // Pre-conditions:
-//   All elements in targetList must be unique, or else they will remain duplicated.
-// Pushes element to targetList and return true iff list_elementIsMissing.
+//   * All elements in targetList must be unique according to compareEqual, or else they will remain duplicated.
+// Side-effects:
+//   * Pushes element to targetList iff the element was missing according to compareEqual and therefore inserted into targetList.
+// Post-conditions:
+//   * Returns true iff the element was unique and therefore inserted into targetList.
 template <typename T>
-static inline bool list_insert_unique_last(dsr::List<T> &targetList, const T &element) {
-	if (list_elementIsMissing(targetList, element)) {
-		targetList.push(element);
-		return true;
+static inline intptr_t list_insert_unique_last(
+  dsr::List<T> &targetList,
+  const T &element,
+  const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compareEqual = [](const T &leftSide, const T &rightSide) -> bool { return leftSide == rightSide; }
+) {
+	if (list_elementIsMissing<T>(targetList, [&element, &compareEqual](intptr_t otherElementIndex, const T &otherElement) -> bool {
+		return compareEqual(element, otherElement);
+	})) {
+		return list_insert_last<T>(targetList, element);
 	} else {
-		return false;
+		return -1;
 	}
 }
 
-// TODO: Take functions for both equality and sorting.
-// TODO: Assert that the original list is sorted in debug mode.
 // Pre-conditions:
-//   All elements in targetList must be unique, or else they will remain duplicated.
-//   targetList must be sorted in ascending order.
-// Pushes element to a sorted location in targetList and return true iff list_elementIsMissing.
-// Pre-condition; targetList is sorted according to the < operator when beginning the call.
-// Side-effect: targetList will remain sorted if it was sorted from the start.
+//   * All elements in targetList must be unique according to compareEqual, or else they will remain duplicated.
+//     compareEqual defaults to T's == operator if not provided.
+//   * All elements in targetList must be sorted according to sortCompare, so that sortCompare(targetList[n], targetList[n + 1]) is satisfied for all neighboring pairs.
+// Side-effects:
+//   * Pushes element to a sorted location in targetList.
+// Pre-conditions;
+//   * targetList is sorted according to the < operator when beginning the call.
+// Post-conditions:
+//   * Returns element's new index in targetList, or -1 if it was not inserted.
+//   * targetList will remain sorted if it was sorted from the start.
 template <typename T>
-static inline bool list_insert_unique_sorted_ascending(dsr::List<T> &targetList, const T &element) {
-	if (list_elementIsMissing(targetList, element)) {
-		targetList.push(element);
-		intptr_t at = targetList.length() - 1;
-		while (at > 0 && targetList[at] < targetList[at - 1]) {
-			targetList.swap(at, at - 1);
-			at--;
-		}
-		return true;
+static inline intptr_t list_insert_unique_sorted(
+  dsr::List<T> &targetList,
+  const T &element,
+  const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &sortCompare,
+  const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compareEqual = [](const T &leftSide, const T &rightSide) -> bool { return leftSide == rightSide; }
+) {
+	if (list_elementIsMissing<T>(targetList, [&element, &compareEqual](intptr_t otherElementIndex, const T &otherElement) -> bool {
+		return compareEqual(element, otherElement);
+	})) {
+		return list_insert_sorted<T>(targetList, element, sortCompare);
 	} else {
-		return false;
+		return -1;
 	}
 }
 
-// TODO: Having insert union without append is a bit strange, so implement a basic append function as well.
+// Pre-conditions:
+//   * All elements in targetList must be unique according to compareEqual, or else they will remain duplicated.
+//     compareEqual defaults to T's == operator if not provided.
+//   * All elements in targetList must be sorted according to T's <= operator, so that targetList[n] <= targetList[n + 1] is satisfied for all neighboring pairs.
+// Side-effects:
+//   * Pushes element to a sorted location in targetList.
+// Pre-conditions;
+//   * targetList is sorted according to the < operator when beginning the call.
+// Post-conditions:
+//   * Returns element's new index in targetList, or -1 if it was not inserted.
+//   * targetList will remain sorted if it was sorted from the start.
+template <typename T>
+static inline intptr_t list_insert_unique_sorted_ascending(
+  dsr::List<T> &targetList,
+  const T &element,
+  const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compareEqual = [](const T &leftSide, const T &rightSide) -> bool { return leftSide == rightSide; }
+) {
+	return list_insert_unique_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide <= rightSide; }, compareEqual);
+}
 
+// Pre-conditions:
+//   * All elements in targetList must be unique according to compareEqual, or else they will remain duplicated.
+//     compareEqual defaults to T's == operator if not provided.
+//   * All elements in targetList must be sorted according to T's >= operator, so that targetList[n] >= targetList[n + 1] is satisfied for all neighboring pairs.
+// Side-effects:
+//   * Pushes element to a sorted location in targetList.
+// Pre-conditions;
+//   * targetList is sorted according to the < operator when beginning the call.
+// Post-conditions:
+//   * Returns element's new index in targetList, or -1 if it was not inserted.
+//   * targetList will remain sorted if it was sorted from the start.
+template <typename T>
+static inline intptr_t list_insert_unique_sorted_descending(
+  dsr::List<T> &targetList,
+  const T &element,
+  const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compareEqual = [](const T &leftSide, const T &rightSide) -> bool { return leftSide == rightSide; }
+) {
+	return list_insert_unique_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; }, compareEqual);
+}
+
+// TODO: Should a list of new indices by returned instead of bool?
 // TODO: Create a varargs version starting with nothing and adding unique elements from all lists before returning by value, so that duplicates in the first list are also reduced.
 // TODO: Take a function for equality.
 // Pre-conditions:
-//   All elements in targetList must be unique, or else they will remain duplicated.
-//   targetList and sourceList may not refer to the same list.
+//   * All elements in targetList must be unique, or else they will remain duplicated.
+//   * targetList and sourceList may not refer to the same list.
 // Pushes all elements in sourceList that does not already exist in targetList.
 // Returns true iff any element was pushed to targetList.
 template <typename T>
@@ -438,7 +517,7 @@ static inline bool list_append_unique_last(dsr::List<T> &targetList, const dsr::
 	bool result = false;
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
-		bool newResult = list_insert_unique_last(targetList, sourceList[e]);
+		bool newResult = list_insert_unique_last<T>(targetList, sourceList[e]) != -1;
 		result = result || newResult;
 	}
 	return result;
@@ -458,7 +537,24 @@ static inline bool list_append_unique_sorted_ascending(dsr::List<T> &targetList,
 	bool result = false;
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
-		bool newResult = list_insert_unique_sorted_ascending(targetList, sourceList[e]);
+		bool newResult = list_insert_unique_sorted_ascending<T>(targetList, sourceList[e]) != -1;
+		result = result || newResult;
+	}
+	return result;
+}
+
+// Pre-conditions:
+//   All elements in targetList must be unique, or else they will remain duplicated.
+//   targetList must be sorted in ascending order.
+//   targetList and sourceList may not refer to the same list.
+// Pushes all elements in sourceList that does not already exist in targetList.
+// Returns true iff any element was pushed to targetList.
+template <typename T>
+static inline bool list_append_unique_sorted_descending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+	bool result = false;
+	for (intptr_t e = 0; e < sourceList.length(); e++) {
+		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
+		bool newResult = list_insert_unique_sorted_descending<T>(targetList, sourceList[e]) != -1;
 		result = result || newResult;
 	}
 	return result;
@@ -466,39 +562,40 @@ static inline bool list_append_unique_sorted_ascending(dsr::List<T> &targetList,
 
 // Helper function for heapSort.
 template <typename T>
-static void impl_list_heapify(dsr::List<T>& targetList, intptr_t n, intptr_t i, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
+static void impl_list_heapify(dsr::List<T>& targetList, intptr_t n, intptr_t i, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &sortCompare) {
 	intptr_t largest = i;
 	intptr_t l = 2 * i + 1;
 	intptr_t r = 2 * i + 2;
-	if (l < n && !compare(targetList[l], targetList[largest])) {
+	if (l < n && !sortCompare(targetList[l], targetList[largest])) {
 		largest = l;
 	}
-	if (r < n && !compare(targetList[r], targetList[largest])) {
+	if (r < n && !sortCompare(targetList[r], targetList[largest])) {
 		largest = r;
 	}
 	if (largest != i) {
 		targetList.swap(i, largest);
-		impl_list_heapify(targetList, n, largest, compare);
+		impl_list_heapify(targetList, n, largest, sortCompare);
 	}
 }
 
 // Apply the heap-sort algorithm to targetList.
-// The compare function should return true when leftSide and rightSide are sorted correctly.
+//   The heap-sort algorithm does not preserve a stable order between elements that are equal according to sortCompare.
+// The sortCompare function should return true when leftSide and rightSide are sorted correctly.
 // Pre-condition:
-//   The compare function must return true when leftSide and rightSide are equal, because elements in the list might be identical.
+//   The sortCompare function must return true when leftSide and rightSide are equal, because elements in the list might be identical.
 // Side-effects:
 //   Overwrites the input with the result, by sorting it in-place.
 //   The elements returned by reference in targetList is a permutation of the original elements,
-//   where each neighboring pair of elements satisfy the compare condition.
+//   where each neighboring pair of elements satisfy the sortCompare condition.
 template <typename T>
-static void list_heapSort(List<T>& targetList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
+static void list_heapSort(List<T>& targetList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &sortCompare) {
 	intptr_t n = targetList.length();
 	for (intptr_t i = n / 2 - 1; i >= 0; i--) {
-		dsr::impl_list_heapify(targetList, n, i, compare);
+		dsr::impl_list_heapify(targetList, n, i, sortCompare);
 	}
 	for (intptr_t i = n - 1; i > 0; i--) {
 		targetList.swap(0, i);
-		dsr::impl_list_heapify(targetList, i, 0, compare);
+		dsr::impl_list_heapify<T>(targetList, i, 0, sortCompare);
 	}
 }
 

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -274,7 +274,7 @@ static void list_append_sorted_ascending(dsr::List<T> &targetList, const dsr::Li
 	}
 }
 
-// TODO: Replace _last and _sorted with a template argument that can be passed from list_insertUnion.
+// TODO: Replace _last and _sorted with a template argument that can be passed from list_appendUnique.
 // TODO: Take a function for equality.
 // Pre-conditions:
 //   All elements in targetList must be unique, or else they will remain duplicated.
@@ -322,7 +322,7 @@ static bool list_insertUnique_sorted_ascending(dsr::List<T> &targetList, const T
 // Pushes all elements in sourceList that does not already exist in targetList.
 // Returns true iff any element was pushed to targetList.
 template <typename T>
-static bool list_insertUnion_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+static bool list_appendUnique_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
 	bool result = false;
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
@@ -342,7 +342,7 @@ static bool list_insertUnion_last(dsr::List<T> &targetList, const dsr::List<T> &
 // Pushes all elements in sourceList that does not already exist in targetList.
 // Returns true iff any element was pushed to targetList.
 template <typename T>
-static bool list_insertUnion_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
+static bool list_appendUnique_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
 	bool result = false;
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
 		// Must store the result in a new variable to avoid lazy evaluation with side-effects.

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -86,7 +86,7 @@ List<OUTPUT_TYPE> list_map(const List<INPUT_TYPE> &input, const TemporaryCallbac
 // condition should return true iff the given element should call action,
 // action should return true to continue the loop or false when done.
 template <typename T, bool BACKWARD = false>
-static List<intptr_t> list_forAll(
+static List<intptr_t> list_forEach(
   const dsr::List<T> &list,
   const TemporaryCallback<bool(intptr_t index, const T &element)> &condition,
   const TemporaryCallback<bool(intptr_t index, const T &element)> &action
@@ -170,7 +170,7 @@ template <typename T>
 static inline List<intptr_t> list_findAll(const dsr::List<T> &list, const TemporaryCallback<bool(intptr_t index, const T &element)> &condition) {
 	List<intptr_t> result;
 	// Ascending loop
-	list_forAll<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
+	list_forEach<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
 		result.push(index); // Push the element's index to the list.
 		return true; // Keep iterating over the list.
 	});
@@ -192,7 +192,7 @@ template <typename T>
 static inline intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryCallback<bool(intptr_t index, const T &element)> &condition) {
 	intptr_t result = -1;
 	// Ascending loop
-	list_forAll<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
+	list_forEach<T, false>(list, condition, [&result](intptr_t index, const T &element) -> bool {
 		result = index; // Take the index as the result.
 		return false; // We are done iterating over the list.
 	});
@@ -214,7 +214,7 @@ template <typename T>
 static inline intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<bool(intptr_t index, const T &element)> &condition) {
 	intptr_t result = -1;
 	// Descending loop
-	list_forAll<T, true>(list, condition, [&result](intptr_t index, const T &element) -> bool {
+	list_forEach<T, true>(list, condition, [&result](intptr_t index, const T &element) -> bool {
 		result = index; // Take the index as the result.
 		return false; // We are done iterating over the list.
 	});

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -504,43 +504,21 @@ static inline intptr_t list_insert_unique_sorted_descending(
 	return list_insert_unique_sorted<T>(targetList, element, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; }, compareEqual);
 }
 
-// TODO: Should a list of new indices by returned instead of bool?
-// TODO: Create a varargs version starting with nothing and adding unique elements from all lists before returning by value, so that duplicates in the first list are also reduced.
-// TODO: Take a function for equality.
+// TODO: Create a varargs union function, starting with nothing and adding unique elements from all lists before returning by value, so that duplicates in the first list are also reduced.
+
 // Pre-conditions:
 //   * All elements in targetList must be unique, or else they will remain duplicated.
 //   * targetList and sourceList may not refer to the same list.
 // Pushes all elements in sourceList that does not already exist in targetList.
-// Returns true iff any element was pushed to targetList.
 template <typename T>
-static inline bool list_append_unique_last(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
-	bool result = false;
+static inline void list_append_unique_last(
+  dsr::List<T> &targetList,
+  const dsr::List<T> &sourceList,
+  const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compareEqual = [](const T &leftSide, const T &rightSide) -> bool { return leftSide == rightSide; }
+) {
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
-		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
-		bool newResult = list_insert_unique_last<T>(targetList, sourceList[e]) != -1;
-		result = result || newResult;
+		list_insert_unique_last<T>(targetList, sourceList[e], compareEqual);
 	}
-	return result;
-}
-
-// TODO: Create a varargs version starting with nothing and adding unique elements from all lists before returning by value, so that duplicates in the first list are also reduced.
-// TODO: Take functions for both equality and sorting.
-// TODO: Assert that the original list is sorted in debug mode.
-// Pre-conditions:
-//   All elements in targetList must be unique, or else they will remain duplicated.
-//   targetList must be sorted in ascending order.
-//   targetList and sourceList may not refer to the same list.
-// Pushes all elements in sourceList that does not already exist in targetList.
-// Returns true iff any element was pushed to targetList.
-template <typename T>
-static inline bool list_append_unique_sorted_ascending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
-	bool result = false;
-	for (intptr_t e = 0; e < sourceList.length(); e++) {
-		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
-		bool newResult = list_insert_unique_sorted_ascending<T>(targetList, sourceList[e]) != -1;
-		result = result || newResult;
-	}
-	return result;
 }
 
 // Pre-conditions:
@@ -550,14 +528,31 @@ static inline bool list_append_unique_sorted_ascending(dsr::List<T> &targetList,
 // Pushes all elements in sourceList that does not already exist in targetList.
 // Returns true iff any element was pushed to targetList.
 template <typename T>
-static inline bool list_append_unique_sorted_descending(dsr::List<T> &targetList, const dsr::List<T> &sourceList) {
-	bool result = false;
+static inline void list_append_unique_sorted_ascending(
+  dsr::List<T> &targetList,
+  const dsr::List<T> &sourceList,
+  const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compareEqual = [](const T &leftSide, const T &rightSide) -> bool { return leftSide == rightSide; }
+) {
 	for (intptr_t e = 0; e < sourceList.length(); e++) {
-		// Must store the result in a new variable to avoid lazy evaluation with side-effects.
-		bool newResult = list_insert_unique_sorted_descending<T>(targetList, sourceList[e]) != -1;
-		result = result || newResult;
+		list_insert_unique_sorted_ascending<T>(targetList, sourceList[e], compareEqual);
 	}
-	return result;
+}
+
+// Pre-conditions:
+//   All elements in targetList must be unique, or else they will remain duplicated.
+//   targetList must be sorted in ascending order.
+//   targetList and sourceList may not refer to the same list.
+// Pushes all elements in sourceList that does not already exist in targetList.
+// Returns true iff any element was pushed to targetList.
+template <typename T>
+static inline void list_append_unique_sorted_descending(
+  dsr::List<T> &targetList,
+  const dsr::List<T> &sourceList,
+  const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compareEqual = [](const T &leftSide, const T &rightSide) -> bool { return leftSide == rightSide; }
+) {
+	for (intptr_t e = 0; e < sourceList.length(); e++) {
+		list_insert_unique_sorted_descending<T>(targetList, sourceList[e], compareEqual);
+	}
 }
 
 // Helper function for heapSort.

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -60,27 +60,53 @@ static String& string_toStreamIndented(String& target, const List<T>& collection
 	return target;
 }
 
+// Post-condition: Returns the result of function f from each element of input.
 template <typename OUTPUT_TYPE, typename INPUT_TYPE>
 List<OUTPUT_TYPE> list_map(const List<INPUT_TYPE> &input, const TemporaryCallback<OUTPUT_TYPE(const INPUT_TYPE &element)> &f) {
 	List<OUTPUT_TYPE> result;
 	result.reserve(input.length());
-	for (intptr_t e = 0; e < input.length(); e++) {
-		result.push(f(input[e]));
+	if (f.hasClosure()) {
+		// Optimized loop for calling lambda.
+		for (intptr_t e = 0; e < input.length(); e++) {
+			result.push(f.callWithClosure(input[e]));
+		}
+	} else {
+		// Optimized loop for calling function pointer.
+		for (intptr_t e = 0; e < input.length(); e++) {
+			result.push(f.callWithoutClosure(input[e]));
+		}
 	}
 	return result;
 }
 
-// TODO: Implement list_find_all, returning a list with indices to matching elements, using both == and a custom condition.
-
-// Returns an index to the first element in list matching find, or -1 if none could be found.
+// Returns a list of indices to all elements in list where condition returns true, or an empty list if the condition returned false for all elements.
 template <typename T>
-static intptr_t list_findFirst(const dsr::List<T> &list, const T &find) {
-	for (intptr_t e = 0; e < list.length(); e++) {
-		if (list[e] == find) {
-			return e;
+static List<intptr_t> list_findAll(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
+	List<intptr_t> result;
+	if (condition.hasClosure()) {
+		// Optimized loop for testing lambda condition.
+		for (intptr_t e = 0; e < list.length(); e++) {
+			if (condition.callWithClosure(list[e])) {
+				result.push(e);
+			}
+		}
+	} else {
+		// Optimized loop for testing function pointer condition.
+		for (intptr_t e = 0; e < list.length(); e++) {
+			if (condition.callWithoutClosure(list[e])) {
+				result.push(e);
+			}
 		}
 	}
-	return -1;
+	return result;
+}
+
+// Returns a list of indices to all elements in list matching, or an empty list if there is no match.
+template <typename T>
+static List<intptr_t> list_findAll(const dsr::List<T> &list, const T &find) {
+	return list_findAll<T>(list, [find](const T &element) -> bool {
+		return element == find;
+	});
 }
 
 // Returns an index to the first element in list where condition returns true, or -1 if the condition returned false for all elements.
@@ -94,18 +120,15 @@ static intptr_t list_findFirst(const dsr::List<T> &list, const TemporaryCallback
 	return -1;
 }
 
-// Returns an index to the last element in list matching find, or -1 if none could be found.
+// Returns an index to the first element in list matching find, or -1 if none could be found.
 template <typename T>
-static intptr_t list_findLast(const dsr::List<T> &list, const T &find) {
-	for (intptr_t e = list.length() - 1; e >= 0; e--) {
-		if (list[e] == find) {
-			return e;
-		}
-	}
-	return -1;
+static intptr_t list_findFirst(const dsr::List<T> &list, const T &find) {
+	return list_findFirst<T>(list, [find](const T &element) -> bool {
+		return element == find;
+	});
 }
 
-// Returns an index to the last element in list where condition returns true, or -1 if the condition returned false for all elements.
+// Returns an index to the last element in list matching find, or -1 if none could be found.
 template <typename T>
 static intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<bool(const T &element)> &condition) {
 	for (intptr_t e = list.length() - 1; e >= 0; e--) {
@@ -114,6 +137,14 @@ static intptr_t list_findLast(const dsr::List<T> &list, const TemporaryCallback<
 		}
 	}
 	return -1;
+}
+
+// Returns an index to the last element in list where condition returns true, or -1 if the condition returned false for all elements.
+template <typename T>
+static intptr_t list_findLast(const dsr::List<T> &list, const T &find) {
+	return list_findLast<T>(list, [find](const T &element) -> bool {
+		return element == find;
+	});
 }
 
 // Returns true iff find matches any element in list.

--- a/Source/DFPSR/api/algorithmAPI_List.h
+++ b/Source/DFPSR/api/algorithmAPI_List.h
@@ -246,6 +246,33 @@ inline static void list_insert_last(dsr::List<T> &targetList, const T &element) 
 	targetList.push(element);
 }
 
+// Post-condition: Returns true iff the list is sorted according to compare, meaning that each neigoboring pair of elements in sourceList satisfies the comparison in the compare function.
+template <typename T>
+static bool list_isSorted(const List<T>& sourceList, const TemporaryCallback<bool(const T &leftSide, const T &rightSide)> &compare) {
+	for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
+		if (!compare(sourceList[e], sourceList[e + 1])) {
+			// Not sorted according to compare.
+			return false;
+		}
+	}
+	// Sorted according to compare.
+	return true;
+}
+
+// If you have a default way of sorting T, you can just define comparison operators for the type to avoid referring to a custom comparison function every time.
+// Post-condition: Returns true iff the list is sorted in ascending order according to T's <= operator, meaning that sourceList[n] <= sourceList[n + 1] for all neighboring elements.
+template <typename T>
+static bool list_isSorted_ascending(const List<T>& sourceList) {
+	return list_isSorted<T>(sourceList, [](const T &leftSide, const T &rightSide) -> bool { return leftSide <= rightSide; });
+}
+
+// If you have a default way of sorting T, you can just define comparison operators for the type to avoid referring to a custom comparison function every time.
+// Post-condition: Returns true iff the list is sorted in descending order according to T's >= operator, meaning that sourceList[n] >= sourceList[n + 1] for all neighboring elements.
+template <typename T>
+static bool list_isSorted_descending(const List<T>& sourceList) {
+	return list_isSorted<T>(sourceList, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; });
+}
+
 // TODO: Take the sorting order as a function argument.
 // TODO: Document
 template <typename T>
@@ -416,32 +443,6 @@ static void list_heapSort_ascending(List<T>& targetList) {
 template <typename T>
 static void list_heapSort_descending(List<T>& targetList) {
 	dsr::list_heapSort<T>(targetList, [](const T &leftSide, const T &rightSide) -> bool { return leftSide >= rightSide; });
-}
-
-// TODO: Implement list_isSorted with a custom comparison.
-
-template <typename T>
-static bool list_isSorted_ascending(const List<T>& sourceList) {
-	for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
-		if (sourceList[e] > sourceList[e + 1]) {
-			// Not sorted in ascending order.
-			return false;
-		}
-	}
-	// Sorted in ascending order.
-	return true;
-}
-
-template <typename T>
-static bool list_isSorted_descending(const List<T>& sourceList) {
-	for (intptr_t e = 0; e < sourceList.length() - 1; e++) {
-		if (sourceList[e] < sourceList[e + 1]) {
-			// Not sorted in decending order.
-			return false;
-		}
-	}
-	// Sorted in decending order.
-	return true;
 }
 
 }

--- a/Source/DFPSR/base/StorableCallback.h
+++ b/Source/DFPSR/base/StorableCallback.h
@@ -158,6 +158,30 @@ public:
 			return (*this->functionPointer)(std::forward<ARGS>(args)...);
 		}
 	}
+	// Optimized version of operator (), for when calling the function many times in a row.
+	// Call hasClosure once for all the calls, then choose to call callWithClosure if it returned true, or callWithoutClosure if it returned false.
+	// Pre-condition: The callback may not contain a closure.
+	inline RESULT callWithClosure(ARGS... args) const {
+		#ifndef NDEBUG
+			if (!(this->hasClosure())) {
+				throwError(U"Called callWithClosure on a StorableCallback that does not have a closure!\n");
+			}
+		#endif
+		// Call the invoke function that remembers the nameless lambda type and provides the data.
+		return this->invoke(this->closure, std::forward<ARGS>(args)...);
+	}
+	// Optimized version of operator (), for when calling the function many times in a row.
+	// Call hasClosure once for all the calls, then choose to call callWithClosure if it returned true, or callWithoutClosure if it returned false.
+	// Pre-condition: The callback may not contain a closure.
+	inline RESULT callWithoutClosure(ARGS... args) const {
+		#ifndef NDEBUG
+			if (this->hasClosure()) {
+				throwError(U"Called callWithoutClosure on a StorableCallback that has a closure!\n");
+			}
+		#endif
+		// Call the function pointer directly.
+		return (*this->functionPointer)(std::forward<ARGS>(args)...);
+	}
 	~StorableCallback() {
 		// If the callback has a closure, then decrease the closure's reference count, so that it will be freed once no callback is using it anymore.
 		if (this->closure != nullptr) {

--- a/Source/DFPSR/base/TemporaryCallback.h
+++ b/Source/DFPSR/base/TemporaryCallback.h
@@ -102,6 +102,34 @@ public:
 			return (*this->functionPointer)(std::forward<ARGS>(args)...);
 		}
 	}
+	// Optimized version of operator (), for when calling the function many times in a row.
+	// Call hasClosure once for all the calls, then choose to call callWithClosure if it returned true, or callWithoutClosure if it returned false.
+	// Pre-condition: The callback may not contain a closure.
+	inline RESULT callWithClosure(ARGS... args) const {
+		/* TODO: Can't call throwError from this header, because the string API depends on TemporaryCallback for string splitting.
+		#ifndef NDEBUG
+			if (!(this->hasClosure())) {
+				throwError(U"Called callWithClosure on a TemporaryCallback that does not have a closure!\n");
+			}
+		#endif
+		*/
+		// Call the invoke function that remembers the nameless lambda type and provides the data.
+		return this->invoke(this->closure, std::forward<ARGS>(args)...);
+	}
+	// Optimized version of operator (), for when calling the function many times in a row.
+	// Call hasClosure once for all the calls, then choose to call callWithClosure if it returned true, or callWithoutClosure if it returned false.
+	// Pre-condition: The callback may not contain a closure.
+	inline RESULT callWithoutClosure(ARGS... args) const {
+		/* TODO: Can't call throwError from this header, because the string API depends on TemporaryCallback for string splitting.
+		#ifndef NDEBUG
+			if (this->hasClosure()) {
+				throwError(U"Called callWithoutClosure on a TemporaryCallback that has a closure!\n");
+			}
+		#endif
+		*/
+		// Call the function pointer directly.
+		return (*this->functionPointer)(std::forward<ARGS>(args)...);
+	}
 };
 
 }

--- a/Source/test/test.sh
+++ b/Source/test/test.sh
@@ -33,7 +33,7 @@ then
 	exit 1
 fi
 
-for file in ./tests/*.cpp; do
+for file in ./tests/*Test.cpp; do
 	[ -e $file ] || continue
 	# Get name without path
 	name=${file##*/};

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -1,0 +1,73 @@
+﻿
+#include "../testTools.h"
+#include "../../DFPSR/api/algorithmAPI_List.h"
+
+START_TEST(ListAlgorithm)
+	{ // List sorting with duplicate elements.
+		List<int32_t> myList(5, 2, 18, 6, -1, 4, 6, -64, 2, 45);
+		list_heapSort_ascending(myList);
+		ASSERT_EQUAL(myList, List<int32_t>(-64, -1, 2, 2, 4, 5, 6, 6, 18, 45));
+		list_heapSort_descending(myList);
+		ASSERT_EQUAL(myList, List<int32_t>(45, 18, 6, 6, 5, 4, 2, 2, -1, -64));
+	}
+	{
+		List<int32_t> unsortedSet(7, 5, 2, 4);
+		ASSERT_EQUAL(list_elementExists(unsortedSet, 1), false);
+		ASSERT_EQUAL(list_elementExists(unsortedSet, 2), true);
+		ASSERT_EQUAL(list_elementExists(unsortedSet, 3), false);
+		ASSERT_EQUAL(list_elementExists(unsortedSet, 4), true);
+		ASSERT_EQUAL(list_elementExists(unsortedSet, 5), true);
+		ASSERT_EQUAL(list_elementExists(unsortedSet, 6), false);
+		ASSERT_EQUAL(list_elementExists(unsortedSet, 7), true);
+		ASSERT_EQUAL(list_elementExists(unsortedSet, 8), false);
+		// New value.
+		ASSERT_EQUAL(list_insertUnique_last(unsortedSet, 3), true)
+		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3));
+		// Already exists.
+		ASSERT_EQUAL(list_insertUnique_last(unsortedSet, 5), false)
+		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3));
+		// New value.
+		ASSERT_EQUAL(list_insertUnique_last(unsortedSet, 6), true)
+		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3, 6));
+	}
+	{
+		List<int32_t> unsortedUnion(7, 5, 2, 4);
+		// Nothing is inserted, because all inserted elements already exist.
+		ASSERT_EQUAL(list_insertUnion_last(unsortedUnion, List<int32_t>(5, 2)), false);
+		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4));
+		// Unique values (3 and 6) are inserted at the end.
+		ASSERT_EQUAL(list_insertUnion_last(unsortedUnion, List<int32_t>(3, 5, 6)), true);
+		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4, 3, 6));
+	}
+	{
+		List<int32_t> sortedSet(2, 4, 5, 7);
+		ASSERT_EQUAL(list_elementExists(sortedSet, 1), false);
+		ASSERT_EQUAL(list_elementExists(sortedSet, 2), true);
+		ASSERT_EQUAL(list_elementExists(sortedSet, 3), false);
+		ASSERT_EQUAL(list_elementExists(sortedSet, 4), true);
+		ASSERT_EQUAL(list_elementExists(sortedSet, 5), true);
+		ASSERT_EQUAL(list_elementExists(sortedSet, 6), false);
+		ASSERT_EQUAL(list_elementExists(sortedSet, 7), true);
+		ASSERT_EQUAL(list_elementExists(sortedSet, 8), false);
+		// New value.
+		ASSERT_EQUAL(list_insertUnique_sorted_ascending(sortedSet, 3), true)
+		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 7));
+		// Already exists.
+		ASSERT_EQUAL(list_insertUnique_sorted_ascending(sortedSet, 5), false)
+		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 7));
+		// New value.
+		ASSERT_EQUAL(list_insertUnique_sorted_ascending(sortedSet, 6), true)
+		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 6, 7));
+	}
+	{ // Sorted unions, which are useful for comparing if two sets contain the same values.
+		List<int32_t> sortedUnion(2, 4, 5, 7);
+		// Nothing is inserted, because all inserted elements already exist.
+		ASSERT_EQUAL(list_insertUnion_sorted_ascending(sortedUnion, List<int32_t>(5, 2)), false);
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 4, 5, 7));
+		// Unique values (3 and 6) are inserted in ascending order.
+		ASSERT_EQUAL(list_insertUnion_sorted_ascending(sortedUnion, List<int32_t>(3, 5, 6)), true);
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 3, 4, 5, 6, 7));
+	}
+	// TODO: Test with custom comparison functions.
+	// TODO: Implement bruteforce testing.
+END_TEST

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -141,14 +141,22 @@ START_TEST(ListAlgorithm)
 		list_append_sorted_descending(descendingList, List<int32_t>(1, -63, 236, 634, 54));
 		ASSERT_EQUAL(descendingList, List<int32_t>(634, 236, 236, 64, 54, 12, 6, 2, 1, -4, -63));
 	}
+	{ // Insert elements into unsorted list.
+		List<int32_t> unsortedList(5, 2, 4, 7, 3, 6);
+		list_insert_last(unsortedList, 4);
+		ASSERT_EQUAL(unsortedList, List<int32_t>(5, 2, 4, 7, 3, 6, 4));
+		list_insert_last(unsortedList, 1);
+		ASSERT_EQUAL(unsortedList, List<int32_t>(5, 2, 4, 7, 3, 6, 4, 1));
+	}
+	{ // Apend elements into unsorted list.
+		List<int32_t> unsortedList(5, 2, 4, 7, 3, 6);
+		list_append_last(unsortedList, List<int32_t>(13, 35, 23, 67, 44));
+		ASSERT_EQUAL(unsortedList, List<int32_t>(5, 2, 4, 7, 3, 6, 13, 35, 23, 67, 44));
+	}
 	// TODO: Write more tests.
 	// * list_insertUnique_last
 	// * list_insertUnique_sorted_ascending
 	// * list_insertUnique_sorted_descending
-	// * list_append_last
-	// * list_append_sorted
-	// * list_append_sorted_ascending
-	// * list_append_sorted_descending
 	// * list_appendUnique_last
 	// * list_appendUnique_sorted
 	// * list_appendUnique_sorted_ascending

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -62,17 +62,17 @@ START_TEST(ListAlgorithm)
 		// Find last alive.
 		ASSERT_EQUAL(list_findLast<Person>(people, [](const Person &person) -> bool { return !(person.alive); }), 5);
 	}
-	// TODO: Give better names and write more tests.
+	// TODO: Write more tests.
 	// * list_elementExists
 	// * list_elementIsMissing
 	// * list_insert_last
 	// * list_insert_sorted_ascending
-	// * list_append_last
-	// * list_append_sorted_ascending
 	// * list_insertUnique_last
 	// * list_insertUnique_sorted_ascending
-	// * list_insertUnion_last
-	// * list_insertUnion_sorted_ascending
+	// * list_append_last
+	// * list_append_sorted_ascending
+	// * list_appendUnique_last
+	// * list_appendUnique_sorted_ascending
 
 	{ // List sorting with duplicate elements.
 		List<int32_t> myList(5, 2, 18, 6, -1, 4, 6, -64, 2, 45);
@@ -104,10 +104,10 @@ START_TEST(ListAlgorithm)
 	{
 		List<int32_t> unsortedUnion(7, 5, 2, 4);
 		// Nothing is inserted, because all inserted elements already exist.
-		ASSERT_EQUAL(list_insertUnion_last(unsortedUnion, List<int32_t>(5, 2)), false);
+		ASSERT_EQUAL(list_appendUnique_last(unsortedUnion, List<int32_t>(5, 2)), false);
 		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4));
 		// Unique values (3 and 6) are inserted at the end.
-		ASSERT_EQUAL(list_insertUnion_last(unsortedUnion, List<int32_t>(3, 5, 6)), true);
+		ASSERT_EQUAL(list_appendUnique_last(unsortedUnion, List<int32_t>(3, 5, 6)), true);
 		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4, 3, 6));
 	}
 	{
@@ -133,10 +133,10 @@ START_TEST(ListAlgorithm)
 	{ // Sorted unions, which are useful for comparing if two sets contain the same values.
 		List<int32_t> sortedUnion(2, 4, 5, 7);
 		// Nothing is inserted, because all inserted elements already exist.
-		ASSERT_EQUAL(list_insertUnion_sorted_ascending(sortedUnion, List<int32_t>(5, 2)), false);
+		ASSERT_EQUAL(list_appendUnique_sorted_ascending(sortedUnion, List<int32_t>(5, 2)), false);
 		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 4, 5, 7));
 		// Unique values (3 and 6) are inserted in ascending order.
-		ASSERT_EQUAL(list_insertUnion_sorted_ascending(sortedUnion, List<int32_t>(3, 5, 6)), true);
+		ASSERT_EQUAL(list_appendUnique_sorted_ascending(sortedUnion, List<int32_t>(3, 5, 6)), true);
 		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 3, 4, 5, 6, 7));
 	}
 	// TODO: Test with custom comparison functions.

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -81,17 +81,56 @@ START_TEST(ListAlgorithm)
 		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>(2)), true);
 		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>()), true);
 	}
+	{ // Insert elements into ascending list.
+		List<int32_t> ascendingList(-4, 2, 6, 12, 64, 236);
+		list_insert_sorted_ascending(ascendingList, 1);
+		ASSERT_EQUAL(ascendingList, List<int32_t>(-4, 1, 2, 6, 12, 64, 236));
+		list_insert_sorted_ascending(ascendingList, -63);
+		ASSERT_EQUAL(ascendingList, List<int32_t>(-63, -4, 1, 2, 6, 12, 64, 236));
+		list_insert_sorted_ascending(ascendingList, 236);
+		ASSERT_EQUAL(ascendingList, List<int32_t>(-63, -4, 1, 2, 6, 12, 64, 236, 236));
+		list_insert_sorted_ascending(ascendingList, 634);
+		ASSERT_EQUAL(ascendingList, List<int32_t>(-63, -4, 1, 2, 6, 12, 64, 236, 236, 634));
+		list_insert_sorted_ascending(ascendingList, 54);
+		ASSERT_EQUAL(ascendingList, List<int32_t>(-63, -4, 1, 2, 6, 12, 54, 64, 236, 236, 634));
+	}
+	{ // Insert elements into ascending list.
+		List<int32_t> ascendingList(-4, 2, 6, 12, 64, 236);
+		list_append_sorted_ascending(ascendingList, List<int32_t>(1, -63, 236, 634, 54));
+		ASSERT_EQUAL(ascendingList, List<int32_t>(-63, -4, 1, 2, 6, 12, 54, 64, 236, 236, 634));
+	}
+	{ // Insert elements into descending list.
+		List<int32_t> descendingList(236, 64, 12, 6, 2, -4);
+		list_insert_sorted_descending(descendingList, 1);
+		ASSERT_EQUAL(descendingList, List<int32_t>(236, 64, 12, 6, 2, 1, -4));
+		list_insert_sorted_descending(descendingList, -63);
+		ASSERT_EQUAL(descendingList, List<int32_t>(236, 64, 12, 6, 2, 1, -4, -63));
+		list_insert_sorted_descending(descendingList, 236);
+		ASSERT_EQUAL(descendingList, List<int32_t>(236, 236, 64, 12, 6, 2, 1, -4, -63));
+		list_insert_sorted_descending(descendingList, 634);
+		ASSERT_EQUAL(descendingList, List<int32_t>(634, 236, 236, 64, 12, 6, 2, 1, -4, -63));
+		list_insert_sorted_descending(descendingList, 54);
+		ASSERT_EQUAL(descendingList, List<int32_t>(634, 236, 236, 64, 54, 12, 6, 2, 1, -4, -63));
+	}
+	{ // Insert elements into descending list.
+		List<int32_t> descendingList(236, 64, 12, 6, 2, -4);
+		list_append_sorted_descending(descendingList, List<int32_t>(1, -63, 236, 634, 54));
+		ASSERT_EQUAL(descendingList, List<int32_t>(634, 236, 236, 64, 54, 12, 6, 2, 1, -4, -63));
+	}
 	// TODO: Write more tests.
 	// * list_elementExists
 	// * list_elementIsMissing
-	// * list_insert_last
-	// * list_insert_sorted_ascending
 	// * list_insertUnique_last
 	// * list_insertUnique_sorted_ascending
+	// * list_insertUnique_sorted_descending
 	// * list_append_last
+	// * list_append_sorted
 	// * list_append_sorted_ascending
+	// * list_append_sorted_descending
 	// * list_appendUnique_last
+	// * list_appendUnique_sorted
 	// * list_appendUnique_sorted_ascending
+	// * list_appendUnique_sorted_descending
 
 	{ // List sorting with duplicate elements.
 		List<int32_t> myList(5, 2, 18, 6, -1, 4, 6, -64, 2, 45);

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -154,13 +154,13 @@ START_TEST(ListAlgorithm)
 		ASSERT_EQUAL(unsortedList, List<int32_t>(5, 2, 4, 7, 3, 6, 13, 35, 23, 67, 44));
 	}
 	// TODO: Write more tests.
-	// * list_insertUnique_last
-	// * list_insertUnique_sorted_ascending
-	// * list_insertUnique_sorted_descending
-	// * list_appendUnique_last
-	// * list_appendUnique_sorted
-	// * list_appendUnique_sorted_ascending
-	// * list_appendUnique_sorted_descending
+	// * list_insert_unique_last
+	// * list_insert_unique_sorted_ascending
+	// * list_insert_unique_sorted_descending
+	// * list_append_unique_last
+	// * list_append_unique_sorted
+	// * list_append_unique_sorted_ascending
+	// * list_append_unique_sorted_descending
 
 	{ // List sorting with duplicate elements.
 		List<int32_t> myList(5, 2, 18, 6, -1, 4, 6, -64, 2, 45);
@@ -180,22 +180,22 @@ START_TEST(ListAlgorithm)
 		ASSERT_EQUAL(list_elementExists(unsortedSet, 7), true);
 		ASSERT_EQUAL(list_elementExists(unsortedSet, 8), false);
 		// New value.
-		ASSERT_EQUAL(list_insertUnique_last(unsortedSet, 3), true)
+		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 3), true)
 		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3));
 		// Already exists.
-		ASSERT_EQUAL(list_insertUnique_last(unsortedSet, 5), false)
+		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 5), false)
 		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3));
 		// New value.
-		ASSERT_EQUAL(list_insertUnique_last(unsortedSet, 6), true)
+		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 6), true)
 		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3, 6));
 	}
 	{
 		List<int32_t> unsortedUnion(7, 5, 2, 4);
 		// Nothing is inserted, because all inserted elements already exist.
-		ASSERT_EQUAL(list_appendUnique_last(unsortedUnion, List<int32_t>(5, 2)), false);
+		ASSERT_EQUAL(list_append_unique_last(unsortedUnion, List<int32_t>(5, 2)), false);
 		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4));
 		// Unique values (3 and 6) are inserted at the end.
-		ASSERT_EQUAL(list_appendUnique_last(unsortedUnion, List<int32_t>(3, 5, 6)), true);
+		ASSERT_EQUAL(list_append_unique_last(unsortedUnion, List<int32_t>(3, 5, 6)), true);
 		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4, 3, 6));
 	}
 	{
@@ -209,22 +209,22 @@ START_TEST(ListAlgorithm)
 		ASSERT_EQUAL(list_elementExists(sortedSet, 7), true);
 		ASSERT_EQUAL(list_elementExists(sortedSet, 8), false);
 		// New value.
-		ASSERT_EQUAL(list_insertUnique_sorted_ascending(sortedSet, 3), true)
+		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 3), true)
 		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 7));
 		// Already exists.
-		ASSERT_EQUAL(list_insertUnique_sorted_ascending(sortedSet, 5), false)
+		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 5), false)
 		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 7));
 		// New value.
-		ASSERT_EQUAL(list_insertUnique_sorted_ascending(sortedSet, 6), true)
+		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 6), true)
 		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 6, 7));
 	}
 	{ // Sorted unions, which are useful for comparing if two sets contain the same values.
 		List<int32_t> sortedUnion(2, 4, 5, 7);
 		// Nothing is inserted, because all inserted elements already exist.
-		ASSERT_EQUAL(list_appendUnique_sorted_ascending(sortedUnion, List<int32_t>(5, 2)), false);
+		ASSERT_EQUAL(list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(5, 2)), false);
 		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 4, 5, 7));
 		// Unique values (3 and 6) are inserted in ascending order.
-		ASSERT_EQUAL(list_appendUnique_sorted_ascending(sortedUnion, List<int32_t>(3, 5, 6)), true);
+		ASSERT_EQUAL(list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(3, 5, 6)), true);
 		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 3, 4, 5, 6, 7));
 	}
 	// TODO: Test with custom comparison functions.

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -2,7 +2,78 @@
 #include "../testTools.h"
 #include "../../DFPSR/api/algorithmAPI_List.h"
 
+int32_t doubleValue(const int32_t &element) {
+	return element * 2;
+}
+
+struct Person {
+	int32_t birthYear;
+	bool alive;
+	Person(int32_t birthYear, bool alive)
+	: birthYear(birthYear), alive(alive) {}
+};
+
 START_TEST(ListAlgorithm)
+	{ // Map to and from the same type using function pointer.
+		// Using the map function instead of pushing from a loop will only have to allocate the output and ask if the function has a closure once for all calls.
+		List<int32_t> input(1, 2, 3, 4, 5);
+		List<int32_t> output = list_map<int32_t, int32_t>(input, &doubleValue);
+		ASSERT_EQUAL(output, List<int32_t>(2, 4, 6, 8, 10));
+		input.clear();
+		output = list_map<int32_t, int32_t>(input, &doubleValue);
+		ASSERT_EQUAL(output, List<int32_t>());
+	}
+	{ // Map to and from the same type using lambda.
+		List<int32_t> input(1, 2, 3, 4, 5);
+		List<int32_t> output = list_map<int32_t, int32_t>(input, [](const int32_t &element) -> int32_t {
+			return element * 2;
+		});
+		ASSERT_EQUAL(output, List<int32_t>(2, 4, 6, 8, 10));
+	}
+	{ // Map to different type using lambda.
+		List<int32_t> input(8, 5, 7, 3);
+		List<String> output = list_map<String, int32_t>(input, [](const int32_t &element) -> String {
+			return string_combine(element + 1);
+		});
+		ASSERT_EQUAL(output, List<String>(U"9", U"6", U"8", U"4"));
+	}
+	{ // Find using custom criteria.
+		List<Person> people(
+			Person(1584, false), // 0
+			Person(1714, false), // 1
+			Person(1825, false), // 2
+			Person(1983, true),  // 3
+			Person(1990, true),  // 4
+			Person(2009, false), // 5
+			Person(2012, true)   // 6
+		);
+		// Find all alive.
+		List<intptr_t> alivePersonIndices = list_findAll<Person>(people, [](const Person &person) -> bool { return person.alive; });
+		ASSERT_EQUAL(alivePersonIndices, List<intptr_t>(3, 4, 6));
+		// Find all dead.
+		List<intptr_t> deadPersonIndices = list_findAll<Person>(people, [](const Person &person) -> bool { return !(person.alive); });
+		ASSERT_EQUAL(deadPersonIndices, List<intptr_t>(0, 1, 2, 5));
+		// Find first alive.
+		ASSERT_EQUAL(list_findFirst<Person>(people, [](const Person &person) -> bool { return person.alive; }), 3);
+		// Find first dead.
+		ASSERT_EQUAL(list_findFirst<Person>(people, [](const Person &person) -> bool { return !(person.alive); }), 0);
+		// Find last alive.
+		ASSERT_EQUAL(list_findLast<Person>(people, [](const Person &person) -> bool { return person.alive; }), 6);
+		// Find last alive.
+		ASSERT_EQUAL(list_findLast<Person>(people, [](const Person &person) -> bool { return !(person.alive); }), 5);
+	}
+	// TODO: Give better names and write more tests.
+	// * list_elementExists
+	// * list_elementIsMissing
+	// * list_insert_last
+	// * list_insert_sorted_ascending
+	// * list_append_last
+	// * list_append_sorted_ascending
+	// * list_insertUnique_last
+	// * list_insertUnique_sorted_ascending
+	// * list_insertUnion_last
+	// * list_insertUnion_sorted_ascending
+
 	{ // List sorting with duplicate elements.
 		List<int32_t> myList(5, 2, 18, 6, -1, 4, 6, -64, 2, 45);
 		list_heapSort_ascending(myList);

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -163,14 +163,6 @@ START_TEST(ListAlgorithm)
 		list_append_last(unsortedList, List<int32_t>(13, 35, 23, 67, 44));
 		ASSERT_EQUAL(unsortedList, List<int32_t>(5, 2, 4, 7, 3, 6, 13, 35, 23, 67, 44));
 	}
-	// TODO: Write more tests.
-	// * list_insert_unique_last
-	// * list_insert_unique_sorted_ascending
-	// * list_insert_unique_sorted_descending
-	// * list_append_unique_last
-	// * list_append_unique_sorted
-	// * list_append_unique_sorted_ascending
-	// * list_append_unique_sorted_descending
 
 	{ // List sorting with duplicate elements.
 		List<int32_t> myList(5, 2, 18, 6, -1, 4, 6, -64, 2, 45);
@@ -179,63 +171,75 @@ START_TEST(ListAlgorithm)
 		list_heapSort_descending(myList);
 		ASSERT_EQUAL(myList, List<int32_t>(45, 18, 6, 6, 5, 4, 2, 2, -1, -64));
 	}
-	{
-		List<int32_t> unsortedSet(7, 5, 2, 4);
-		ASSERT_EQUAL(list_elementExists(unsortedSet, 1), false);
-		ASSERT_EQUAL(list_elementExists(unsortedSet, 2), true);
-		ASSERT_EQUAL(list_elementExists(unsortedSet, 3), false);
-		ASSERT_EQUAL(list_elementExists(unsortedSet, 4), true);
-		ASSERT_EQUAL(list_elementExists(unsortedSet, 5), true);
-		ASSERT_EQUAL(list_elementExists(unsortedSet, 6), false);
-		ASSERT_EQUAL(list_elementExists(unsortedSet, 7), true);
-		ASSERT_EQUAL(list_elementExists(unsortedSet, 8), false);
+	{ // Insert and addend into unsorted unions.
+		// Unless you know for sure that there are no duplicates,
+		//   always start from an empty collection when creating a union.
+		List<int32_t> unsortedUnion;
+		list_append_unique_last(unsortedUnion, List<int32_t>(7, 5, 2, 2, 2, 4, 2, 7, 2, 4, 5, 2, 2));
+		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4));
+		ASSERT_EQUAL(list_elementExists(unsortedUnion, 1), false);
+		ASSERT_EQUAL(list_elementExists(unsortedUnion, 2), true);
+		ASSERT_EQUAL(list_elementExists(unsortedUnion, 3), false);
+		ASSERT_EQUAL(list_elementExists(unsortedUnion, 4), true);
+		ASSERT_EQUAL(list_elementExists(unsortedUnion, 5), true);
+		ASSERT_EQUAL(list_elementExists(unsortedUnion, 6), false);
+		ASSERT_EQUAL(list_elementExists(unsortedUnion, 7), true);
+		ASSERT_EQUAL(list_elementExists(unsortedUnion, 8), false);
 		// New value.
-		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 3), 4)
-		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3));
+		ASSERT_EQUAL(list_insert_unique_last(unsortedUnion, 3), 4)
+		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4, 3));
 		// Already exists.
-		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 5), -1)
-		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3));
+		ASSERT_EQUAL(list_insert_unique_last(unsortedUnion, 5), -1)
+		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4, 3));
 		// New value.
-		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 6), 5)
-		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3, 6));
-	}
-	{
-		List<int32_t> unsortedUnion(7, 5, 2, 4);
+		ASSERT_EQUAL(list_insert_unique_last(unsortedUnion, 6), 5)
+		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4, 3, 6));
 		// Nothing is inserted, because all inserted elements already exist.
 		list_append_unique_last(unsortedUnion, List<int32_t>(5, 2));
-		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4));
-		// Unique values (3 and 6) are inserted at the end.
-		list_append_unique_last(unsortedUnion, List<int32_t>(3, 5, 6));
 		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4, 3, 6));
+		// Unique values (1 and 9) are inserted at the end.
+		list_append_unique_last(unsortedUnion, List<int32_t>(1, 5, 9));
+		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4, 3, 6, 1, 9));
 	}
-	{
-		List<int32_t> sortedSet(2, 4, 5, 7);
-		ASSERT_EQUAL(list_elementExists(sortedSet, 1), false);
-		ASSERT_EQUAL(list_elementExists(sortedSet, 2), true);
-		ASSERT_EQUAL(list_elementExists(sortedSet, 3), false);
-		ASSERT_EQUAL(list_elementExists(sortedSet, 4), true);
-		ASSERT_EQUAL(list_elementExists(sortedSet, 5), true);
-		ASSERT_EQUAL(list_elementExists(sortedSet, 6), false);
-		ASSERT_EQUAL(list_elementExists(sortedSet, 7), true);
-		ASSERT_EQUAL(list_elementExists(sortedSet, 8), false);
-		// New value.
-		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 3), 1)
-		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 7));
-		// Already exists.
-		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 5), -1)
-		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 7));
-		// New value.
-		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 6), 4)
-		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 6, 7));
-	}
-	{ // Sorted unions, which are useful for comparing if two sets contain the same values.
-		List<int32_t> sortedUnion(2, 4, 5, 7);
-		// Nothing is inserted, because all inserted elements already exist.
-		list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(5, 2));
+	{ // Insert and addend into ascending sorted unions.
+		// Unless you know for sure that there are no duplicates nor unsorted elements,
+		//   always start from an empty collection when creating a union.
+		List<int32_t> sortedUnion;
+		list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(7, 5, 2, 2, 2, 4, 2, 7, 2, 4, 5, 2, 2));
 		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 4, 5, 7));
-		// Unique values (3 and 6) are inserted in ascending order.
-		list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(3, 5, 6));
+		// New value.
+		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedUnion, 3), 1)
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 3, 4, 5, 7));
+		// Already exists.
+		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedUnion, 5), -1)
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 3, 4, 5, 7));
+		// New value.
+		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedUnion, 6), 4)
 		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 3, 4, 5, 6, 7));
+		// Unique values (1 and 9) are inserted at the start and end.
+		list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(1, 5, 9));
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(1, 2, 3, 4, 5, 6, 7, 9));
+	}
+	{ // Insert and addend into descending sorted unions.
+		// Unless you know for sure that there are no duplicates nor unsorted elements,
+		//   always start from an empty collection when creating a union.
+		List<int32_t> sortedUnion;
+		list_append_unique_sorted_descending(sortedUnion, List<int32_t>(7, 5, 2, 2, 2, 4, 2, 7, 2, 4, 5, 2, 2));
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(7, 5, 4, 2));
+		// New value 3 at index 3.
+		ASSERT_EQUAL(list_insert_unique_sorted_descending(sortedUnion, 3), 3)
+		//                                               _
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(7, 5, 4, 3, 2));
+		// Already exists.
+		ASSERT_EQUAL(list_insert_unique_sorted_descending(sortedUnion, 5), -1)
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(7, 5, 4, 3, 2));
+		// New value.
+		ASSERT_EQUAL(list_insert_unique_sorted_descending(sortedUnion, 6), 1)
+		//                                         _
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(7, 6, 5, 4, 3, 2));
+		// Unique values (1 and 9) are inserted at the start and end.
+		list_append_unique_sorted_descending(sortedUnion, List<int32_t>(1, 5, 9));
+		ASSERT_EQUAL(sortedUnion, List<int32_t>(9, 7, 6, 5, 4, 3, 2, 1));
 	}
 	// TODO: Test with custom comparison functions.
 	// TODO: Implement bruteforce testing.

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -202,10 +202,10 @@ START_TEST(ListAlgorithm)
 	{
 		List<int32_t> unsortedUnion(7, 5, 2, 4);
 		// Nothing is inserted, because all inserted elements already exist.
-		ASSERT_EQUAL(list_append_unique_last(unsortedUnion, List<int32_t>(5, 2)), false);
+		list_append_unique_last(unsortedUnion, List<int32_t>(5, 2));
 		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4));
 		// Unique values (3 and 6) are inserted at the end.
-		ASSERT_EQUAL(list_append_unique_last(unsortedUnion, List<int32_t>(3, 5, 6)), true);
+		list_append_unique_last(unsortedUnion, List<int32_t>(3, 5, 6));
 		ASSERT_EQUAL(unsortedUnion, List<int32_t>(7, 5, 2, 4, 3, 6));
 	}
 	{
@@ -231,10 +231,10 @@ START_TEST(ListAlgorithm)
 	{ // Sorted unions, which are useful for comparing if two sets contain the same values.
 		List<int32_t> sortedUnion(2, 4, 5, 7);
 		// Nothing is inserted, because all inserted elements already exist.
-		ASSERT_EQUAL(list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(5, 2)), false);
+		list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(5, 2));
 		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 4, 5, 7));
 		// Unique values (3 and 6) are inserted in ascending order.
-		ASSERT_EQUAL(list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(3, 5, 6)), true);
+		list_append_unique_sorted_ascending(sortedUnion, List<int32_t>(3, 5, 6));
 		ASSERT_EQUAL(sortedUnion, List<int32_t>(2, 3, 4, 5, 6, 7));
 	}
 	// TODO: Test with custom comparison functions.

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -62,6 +62,25 @@ START_TEST(ListAlgorithm)
 		// Find last alive.
 		ASSERT_EQUAL(list_findLast<Person>(people, [](const Person &person) -> bool { return !(person.alive); }), 5);
 	}
+	{ // Checking if a list is sorted.
+		ASSERT_EQUAL(list_isSorted_ascending(List<int32_t>()), true);
+		ASSERT_EQUAL(list_isSorted_ascending(List<int32_t>(1)), true);
+		ASSERT_EQUAL(list_isSorted_ascending(List<int32_t>(1, 2)), true);
+		ASSERT_EQUAL(list_isSorted_ascending(List<int32_t>(1, 2, 3)), true);
+		ASSERT_EQUAL(list_isSorted_ascending(List<int32_t>(1, 2, 3, 4)), true);
+		ASSERT_EQUAL(list_isSorted_ascending(List<int32_t>(1, 3, 2, 4)), false);
+		ASSERT_EQUAL(list_isSorted_ascending(List<int32_t>(4, 3, 2, 1)), false);
+		ASSERT_EQUAL(list_isSorted_ascending(List<int32_t>(1, 1, 2, 2, 3, 3, 4, 4)), true);
+		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>(4, 4, 3, 3, 2, 2, 1, 1)), true);
+		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>(1, 2, 3, 4)), false);
+		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>(1, 3, 2, 4)), false);
+		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>(4, 3, 2, 1)), true);
+		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>(4, 3, 2)), true);
+		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>(3, 2, 1)), true);
+		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>(3, 2)), true);
+		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>(2)), true);
+		ASSERT_EQUAL(list_isSorted_descending(List<int32_t>()), true);
+	}
 	// TODO: Write more tests.
 	// * list_elementExists
 	// * list_elementIsMissing

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -72,19 +72,19 @@ START_TEST(ListAlgorithm)
 			Person(2012, true)   // 6
 		);
 		// Find all alive.
-		List<intptr_t> alivePersonIndices = list_findAll<Person>(people, [](const Person &person) -> bool { return person.alive; });
+		List<intptr_t> alivePersonIndices = list_findAll<Person>(people, [](intptr_t index, const Person &person) -> bool { return person.alive; });
 		ASSERT_EQUAL(alivePersonIndices, List<intptr_t>(3, 4, 6));
 		// Find all dead.
-		List<intptr_t> deadPersonIndices = list_findAll<Person>(people, [](const Person &person) -> bool { return !(person.alive); });
+		List<intptr_t> deadPersonIndices = list_findAll<Person>(people, [](intptr_t index, const Person &person) -> bool { return !(person.alive); });
 		ASSERT_EQUAL(deadPersonIndices, List<intptr_t>(0, 1, 2, 5));
 		// Find first alive.
-		ASSERT_EQUAL(list_findFirst<Person>(people, [](const Person &person) -> bool { return person.alive; }), 3);
+		ASSERT_EQUAL(list_findFirst<Person>(people, [](intptr_t index, const Person &person) -> bool { return person.alive; }), 3);
 		// Find first dead.
-		ASSERT_EQUAL(list_findFirst<Person>(people, [](const Person &person) -> bool { return !(person.alive); }), 0);
+		ASSERT_EQUAL(list_findFirst<Person>(people, [](intptr_t index, const Person &person) -> bool { return !(person.alive); }), 0);
 		// Find last alive.
-		ASSERT_EQUAL(list_findLast<Person>(people, [](const Person &person) -> bool { return person.alive; }), 6);
+		ASSERT_EQUAL(list_findLast<Person>(people, [](intptr_t index, const Person &person) -> bool { return person.alive; }), 6);
 		// Find last alive.
-		ASSERT_EQUAL(list_findLast<Person>(people, [](const Person &person) -> bool { return !(person.alive); }), 5);
+		ASSERT_EQUAL(list_findLast<Person>(people, [](intptr_t index, const Person &person) -> bool { return !(person.alive); }), 5);
 	}
 	{ // Checking if a list is sorted.
 		ASSERT_EQUAL(list_isSorted_ascending(List<int32_t>()), true);
@@ -107,15 +107,20 @@ START_TEST(ListAlgorithm)
 	}
 	{ // Insert elements into ascending list.
 		List<int32_t> ascendingList(-4, 2, 6, 12, 64, 236);
-		list_insert_sorted_ascending(ascendingList, 1);
+		ASSERT_EQUAL(list_insert_sorted_ascending(ascendingList, 1), 1); // Inserted at index 1.
+		//                                            _
 		ASSERT_EQUAL(ascendingList, List<int32_t>(-4, 1, 2, 6, 12, 64, 236));
-		list_insert_sorted_ascending(ascendingList, -63);
+		ASSERT_EQUAL(list_insert_sorted_ascending(ascendingList, -63), 0); // Inserted at index 0.
+		//                                        ___
 		ASSERT_EQUAL(ascendingList, List<int32_t>(-63, -4, 1, 2, 6, 12, 64, 236));
-		list_insert_sorted_ascending(ascendingList, 236);
+		ASSERT_EQUAL(list_insert_sorted_ascending(ascendingList, 236), 8); // Inserted at index 8.
+		//                                                                       ___
 		ASSERT_EQUAL(ascendingList, List<int32_t>(-63, -4, 1, 2, 6, 12, 64, 236, 236));
-		list_insert_sorted_ascending(ascendingList, 634);
+		ASSERT_EQUAL(list_insert_sorted_ascending(ascendingList, 634), 9); // Inserted at index 9.
+		//                                                                            ___
 		ASSERT_EQUAL(ascendingList, List<int32_t>(-63, -4, 1, 2, 6, 12, 64, 236, 236, 634));
-		list_insert_sorted_ascending(ascendingList, 54);
+		ASSERT_EQUAL(list_insert_sorted_ascending(ascendingList, 54), 6); // Inserted at index 6.
+		//                                                              __
 		ASSERT_EQUAL(ascendingList, List<int32_t>(-63, -4, 1, 2, 6, 12, 54, 64, 236, 236, 634));
 	}
 	{ // Insert elements into ascending list.
@@ -125,15 +130,20 @@ START_TEST(ListAlgorithm)
 	}
 	{ // Insert elements into descending list.
 		List<int32_t> descendingList(236, 64, 12, 6, 2, -4);
-		list_insert_sorted_descending(descendingList, 1);
+		ASSERT_EQUAL(list_insert_sorted_descending(descendingList, 1), 5);
+		//                                                            _
 		ASSERT_EQUAL(descendingList, List<int32_t>(236, 64, 12, 6, 2, 1, -4));
-		list_insert_sorted_descending(descendingList, -63);
+		ASSERT_EQUAL(list_insert_sorted_descending(descendingList, -63), 7);
+		//                                                                   ___
 		ASSERT_EQUAL(descendingList, List<int32_t>(236, 64, 12, 6, 2, 1, -4, -63));
-		list_insert_sorted_descending(descendingList, 236);
+		ASSERT_EQUAL(list_insert_sorted_descending(descendingList, 236), 1);
+		//                                              ___
 		ASSERT_EQUAL(descendingList, List<int32_t>(236, 236, 64, 12, 6, 2, 1, -4, -63));
-		list_insert_sorted_descending(descendingList, 634);
+		ASSERT_EQUAL(list_insert_sorted_descending(descendingList, 634), 0);
+		//                                         ___
 		ASSERT_EQUAL(descendingList, List<int32_t>(634, 236, 236, 64, 12, 6, 2, 1, -4, -63));
-		list_insert_sorted_descending(descendingList, 54);
+		ASSERT_EQUAL(list_insert_sorted_descending(descendingList, 54), 4);
+		//                                                            __
 		ASSERT_EQUAL(descendingList, List<int32_t>(634, 236, 236, 64, 54, 12, 6, 2, 1, -4, -63));
 	}
 	{ // Insert elements into descending list.
@@ -180,13 +190,13 @@ START_TEST(ListAlgorithm)
 		ASSERT_EQUAL(list_elementExists(unsortedSet, 7), true);
 		ASSERT_EQUAL(list_elementExists(unsortedSet, 8), false);
 		// New value.
-		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 3), true)
+		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 3), 4)
 		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3));
 		// Already exists.
-		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 5), false)
+		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 5), -1)
 		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3));
 		// New value.
-		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 6), true)
+		ASSERT_EQUAL(list_insert_unique_last(unsortedSet, 6), 5)
 		ASSERT_EQUAL(unsortedSet, List<int32_t>(7, 5, 2, 4, 3, 6));
 	}
 	{
@@ -209,13 +219,13 @@ START_TEST(ListAlgorithm)
 		ASSERT_EQUAL(list_elementExists(sortedSet, 7), true);
 		ASSERT_EQUAL(list_elementExists(sortedSet, 8), false);
 		// New value.
-		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 3), true)
+		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 3), 1)
 		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 7));
 		// Already exists.
-		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 5), false)
+		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 5), -1)
 		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 7));
 		// New value.
-		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 6), true)
+		ASSERT_EQUAL(list_insert_unique_sorted_ascending(sortedSet, 6), 4)
 		ASSERT_EQUAL(sortedSet, List<int32_t>(2, 3, 4, 5, 6, 7));
 	}
 	{ // Sorted unions, which are useful for comparing if two sets contain the same values.

--- a/Source/test/tests/ListAlgorithmTest.cpp
+++ b/Source/test/tests/ListAlgorithmTest.cpp
@@ -37,6 +37,30 @@ START_TEST(ListAlgorithm)
 		});
 		ASSERT_EQUAL(output, List<String>(U"9", U"6", U"8", U"4"));
 	}
+	{ // Find elements in lists.
+		List<int32_t> values(4, 1, 3, 7, 34, 72, 2, 45, 6, 4, 7, 7, 2);
+		// Check if 7 exists.
+		ASSERT_EQUAL(list_elementExists(values, 7), true);
+		ASSERT_EQUAL(list_elementIsMissing(values, 7), false);
+		// Find the first 7 at index 3 in values.
+		ASSERT_EQUAL(list_findFirst(values, 7), 3);
+		// Find the last 7 at index 11 in values.
+		ASSERT_EQUAL(list_findLast(values, 7), 11);
+		// Find the last 7 at indices 3, 10 and 11 in values.
+		ASSERT_EQUAL(list_findAll(values, 7), List<intptr_t>(3, 10, 11));
+		// Value 7 does not exist in an empty list.
+		ASSERT_EQUAL(list_elementExists(List<int32_t>(), 7), false);
+		ASSERT_EQUAL(list_elementIsMissing(List<int32_t>(), 7), true);
+		ASSERT_EQUAL(list_findFirst(List<int32_t>(), 7), -1);
+		ASSERT_EQUAL(list_findLast(List<int32_t>(), 7), -1);
+		ASSERT_EQUAL(list_findAll(List<int32_t>(), 7), List<intptr_t>());
+		// Value 8 does not exist in the list.
+		ASSERT_EQUAL(list_elementExists(values, 8), false);
+		ASSERT_EQUAL(list_elementIsMissing(values, 8), true);
+		ASSERT_EQUAL(list_findFirst(values, 8), -1);
+		ASSERT_EQUAL(list_findLast(values, 8), -1);
+		ASSERT_EQUAL(list_findAll(values, 8), List<intptr_t>());
+	}
 	{ // Find using custom criteria.
 		List<Person> people(
 			Person(1584, false), // 0
@@ -118,8 +142,6 @@ START_TEST(ListAlgorithm)
 		ASSERT_EQUAL(descendingList, List<int32_t>(634, 236, 236, 64, 54, 12, 6, 2, 1, -4, -63));
 	}
 	// TODO: Write more tests.
-	// * list_elementExists
-	// * list_elementIsMissing
 	// * list_insertUnique_last
 	// * list_insertUnique_sorted_ascending
 	// * list_insertUnique_sorted_descending


### PR DESCRIPTION
Now that std::function is replaced, it is about time to have the commonly re-implemented patterns as template functions in the algorithm API. This allow writing more compact code with less bugs in functional code. Then you don't have to write a new find function for every list, and defining comparison operators for your types makes it easy to keep lists sorted or free from duplicates.

The algorithm API has been divided into one header per type of collection. The algorithm API for dsr::List has been given many new functions for searching, filtering, sorting and inserting elements. There are some optimizations, such as allocating and checking if callbacks have closures in advance, but it is mostly forcused on correctness when writing bruteforce tests and formal proof systems, so there is no SIMD or multi-threading in the algorithm API.

It has been tested with a few handwritten tests to document intended behavior. It is also used to implement formal verification algorithms in my interpreted tokenizer and parser for arbitrary grammars, which might later be used for transpiling and analyzing code.