### PR TITLE
Add riscv target detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Theme, GUI, font and sound APIs are still under active development and may have 
 ## Supported CPU hardware:
 * **Intel/AMD** using **SSE2**, **SSSE3**, **AVX** and **AVX2** intrinsics.
 * **ARM** using **NEON** intrinsics.
+* **RISC-V** currently using the existing scalar fallback path until a dedicated SIMD backend is added.
 * Unknown CPU architectures, by running the same vector operations without SIMD hardware acceleration. This is still faster than naive loops with one iteration per element, because multiple scalar operations in parallel are better at filling the processor's execution window.
 
 ## Supported compilers:

--- a/Source/DFPSR/settings.h
+++ b/Source/DFPSR/settings.h
@@ -42,8 +42,32 @@
 		#error "Could not identify the operating system!\n"
 	#endif
 
+	// If a different target architecture is forced during portability checks, do not let host SIMD builtins leak in.
+	#if defined(__riscv)
+		#ifdef __AVX2__
+			#undef __AVX2__
+		#endif
+		#ifdef __AVX__
+			#undef __AVX__
+		#endif
+		#ifdef __SSSE3__
+			#undef __SSSE3__
+		#endif
+		#ifdef __SSE2__
+			#undef __SSE2__
+		#endif
+		#ifdef __ARM_NEON
+			#undef __ARM_NEON
+		#endif
+	#endif
+
 	// Identify processor types.
-	#if defined(__INTEL__) || defined(__SSE2__)
+	#if defined(__riscv)
+		#define USE_RISCV
+		#if defined(__riscv_xlen) && (__riscv_xlen == 64)
+			#define USE_RISCV64
+		#endif
+	#elif defined(__INTEL__) || defined(__SSE2__)
 		#define USE_INTEL
 	#elif defined(__ARM__) || defined(__ARM_NEON)
 		#define USE_ARM
@@ -56,7 +80,7 @@
 	//   SSE2 and NEON are usually enabled by default on instruction sets where they are not optional, which is good if you just want one release that is fast enough.
 	//   AVX with 256-bit float SIMD is useful for sound and physics that can be computed without integers.
 	//   AVX2 with full 256-bit SIMD is useful for 3D graphics and heavy 2D filters where memory bandwidth is not the bottleneck.
-	#if defined(__SSE2__)
+	#if defined(USE_INTEL) && defined(__SSE2__)
 		#define USE_SSE2 // Comment out this line to test without SSE2
 		#ifdef USE_SSE2
 			#ifdef __SSSE3__
@@ -71,7 +95,7 @@
 				#endif
 			#endif
 		#endif
-	#elif defined(__ARM_NEON)
+	#elif defined(USE_ARM) && defined(__ARM_NEON)
 		#define USE_NEON // Comment out this line to test without NEON
 		// TODO: Check if SVE is enabled once implemented in simd.h.
 	#endif


### PR DESCRIPTION
## Why

DFPSR already documents that unknown CPU architectures can run through the scalar fallback in its SIMD abstraction layer, which makes it a good baseline for `riscv64` portability. However, `Source/DFPSR/settings.h` currently derives the active backend directly from host SIMD builtins such as `__SSE2__`, `__AVX__`, and `__ARM_NEON`. During forced-target or cross-target validation, those host macros can leak into preprocessing and make a `riscv64` portability check incorrectly select x86 or ARM SIMD paths.

## What changed

- Add explicit `__riscv` target detection in `Source/DFPSR/settings.h`, including a `USE_RISCV64` marker when `__riscv_xlen == 64`.
- Clear leaked host SIMD builtins when the target is forced to `__riscv`, so portability checks do not inherit x86 or ARM feature state from the build host.
- Restrict `USE_SSE2`/`USE_SSSE3`/`USE_AVX`/`USE_AVX2` enablement to the detected Intel target path and restrict `USE_NEON` enablement to the detected ARM target path.
- Update `README.md` to document that `RISC-V` currently uses DFPSR's existing scalar fallback path until a dedicated SIMD backend is added.

## Verification

- Ran the native Windows test build successfully:
  - `Source\test\test_windows.bat`
- Confirmed the native Windows test suite built and passed all `30` tests, including `BruteSimdTest` and `SimdTest`.
- Preprocessed `Source/DFPSR/settings.h` on the native x86 host and confirmed the existing host path still reports `USE_INTEL`, `USE_SSE2`, and `USE_BASIC_SIMD`.
- Preprocessed `Source/DFPSR/settings.h` with `-D__riscv=1 -D__riscv_xlen=64` and confirmed it reports `USE_RISCV` and `USE_RISCV64`, without enabling `USE_INTEL`, `USE_ARM`, `USE_SSE2`, `USE_AVX`, `USE_AVX2`, `USE_NEON`, `USE_BASIC_SIMD`, `USE_256BIT_X_SIMD`, or `USE_256BIT_F_SIMD`.
- Compiled a forced-`riscv64` smoke translation unit that includes `DFPSR/base/simd.h`, checks that no x86 or ARM SIMD backend macros leak into the target, and confirms the scalar fallback keeps `laneCountX_32Bit == 4` and `DSR_DEFAULT_ALIGNMENT == 16`.
- Cross-compiled the `basicCLI` template's minimal source set to a static `riscv64` executable in `dockcross/linux-riscv64`.
- Verified the produced executable with:
  - `file`
  - `readelf -h`
- Ran the resulting binary under `qemu-riscv64` and confirmed the expected output:
  - `Hello world`

## Notes

This is a conservative portability patch. It does not add RVV or any other dedicated RISC-V SIMD backend. The goal is to make `riscv64` resolve to DFPSR's existing scalar fallback correctly and to keep cross-target validation from inheriting host SIMD assumptions.